### PR TITLE
Increase handle priority of GLSPDiagramManager

### DIFF
--- a/src/browser/diagram/glsp-diagram-manager.ts
+++ b/src/browser/diagram/glsp-diagram-manager.ts
@@ -41,7 +41,7 @@ export abstract class GLSPDiagramManager extends DiagramManager {
     canHandle(uri: URI, options?: WidgetOpenerOptions | undefined): number {
         for (const extension of this.fileExtensions) {
             if (uri.path.toString().endsWith(extension)) {
-                return 101;
+                return 1001;
             }
         }
         return 0;


### PR DESCRIPTION
Increase the return priority to counteract:
https://github.com/eclipse-theia/theia/blob/07d01332d564b60d051229a8fe323853fb2bc68e/packages/editor-preview/src/browser/editor-preview-manager.ts#L106

Fixes https://github.com/eclipse-glsp/glsp/issues/24

Signed-off-by: Eugen Neufeld <eneufeld@eclipsesource.com>