### PR TITLE
Add support for server message action

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@theia/core": "next",
     "@theia/editor": "next",
     "@theia/filesystem": "next",
+    "@theia/messages": "next",
     "@theia/languages": "next",
     "@theia/monaco": "next",
     "@theia/process": "next",

--- a/src/browser/diagram/glsp-notification-manager.ts
+++ b/src/browser/diagram/glsp-notification-manager.ts
@@ -1,0 +1,36 @@
+/********************************************************************************
+ * Copyright (c) 2020 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+import { Message, MessageOptions } from "@theia/core/lib/common";
+import { NotificationManager } from "@theia/messages/lib/browser/notifications-manager";
+import { Md5 } from "ts-md5";
+
+export class GLSPNotificationManager extends NotificationManager {
+    public getMessageId(message: Message): string {
+        const options = message.options;
+        if (isGLSPMessageOptions(options)) {
+            return String(Md5.hashStr(`[${message.type} @ ${options.uri}] ${message.text} : ${(message.actions || []).join(' | ')};`));
+        }
+        return super.getMessageId(message);
+    }
+}
+
+export interface GLSPMessageOptions extends MessageOptions {
+    uri: string;
+}
+
+function isGLSPMessageOptions(options?: MessageOptions): options is GLSPMessageOptions {
+    return options !== undefined && 'uri' in options;
+}

--- a/src/browser/diagram/glsp-theia-sprotty-connector.ts
+++ b/src/browser/diagram/glsp-theia-sprotty-connector.ts
@@ -56,7 +56,6 @@ export class GLSPTheiaSprottyConnector implements TheiaSprottyConnector, GLSPThe
     readonly messageService: MessageService;
     readonly notificationManager: GLSPNotificationManager;
 
-
     constructor(services: GLSPTheiaSprottyConnectorServices) {
         Object.assign(this, services);
         this.diagramClient.connect(this);

--- a/src/browser/diagram/glsp-theia-sprotty-connector.ts
+++ b/src/browser/diagram/glsp-theia-sprotty-connector.ts
@@ -13,14 +13,23 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import { ActionMessage, ExportSvgAction, isGLSPServerStatusAction, ServerStatusAction } from "@eclipse-glsp/client";
+import {
+    ActionMessage,
+    ExportSvgAction,
+    isGLSPServerStatusAction,
+    remove,
+    ServerMessageAction,
+    ServerStatusAction
+} from "@eclipse-glsp/client";
 import { MessageService } from "@theia/core";
 import { ConfirmDialog, WidgetManager } from "@theia/core/lib/browser";
+import { Message, MessageType } from "@theia/core/lib/common";
 import { EditorManager } from "@theia/editor/lib/browser";
 import { DiagramManager, DiagramWidget, TheiaDiagramServer, TheiaFileSaver, TheiaSprottyConnector } from "sprotty-theia";
 
 import { GLSPClient } from "../language/glsp-client-services";
 import { GLSPDiagramClient } from "./glsp-diagram-client";
+import { GLSPMessageOptions, GLSPNotificationManager } from "./glsp-notification-manager";
 
 export interface GLSPTheiaSprottyConnectorServices {
     readonly diagramClient: GLSPDiagramClient,
@@ -28,13 +37,16 @@ export interface GLSPTheiaSprottyConnectorServices {
     readonly editorManager: EditorManager,
     readonly widgetManager: WidgetManager,
     readonly diagramManager: DiagramManager,
-    readonly messageService: MessageService
+    readonly messageService: MessageService,
+    readonly notificationManager: GLSPNotificationManager
 }
 
 const SHOW_DETAILS_LABEL = 'Show details';
 
 export class GLSPTheiaSprottyConnector implements TheiaSprottyConnector, GLSPTheiaSprottyConnectorServices {
     private servers: Map<String, TheiaDiagramServer> = new Map;
+    private widgetMessages: Map<string, string[]> = new Map;
+    private widgetStatusTimeouts: Map<string, number> = new Map;
 
     readonly diagramClient: GLSPDiagramClient;
     readonly fileSaver: TheiaFileSaver;
@@ -42,6 +54,8 @@ export class GLSPTheiaSprottyConnector implements TheiaSprottyConnector, GLSPThe
     readonly widgetManager: WidgetManager;
     readonly diagramManager: DiagramManager;
     readonly messageService: MessageService;
+    readonly notificationManager: GLSPNotificationManager;
+
 
     constructor(services: GLSPTheiaSprottyConnectorServices) {
         Object.assign(this, services);
@@ -63,59 +77,129 @@ export class GLSPTheiaSprottyConnector implements TheiaSprottyConnector, GLSPThe
         this.fileSaver.save(uri, action);
     }
 
-    showStatus(widgetId: string, status: ServerStatusAction): void {
+    // Status
+
+    showStatus(widgetId: string, action: ServerStatusAction): void {
+        if (this.isClear(action.severity)) {
+            this.clearWidgetStatus(widgetId);
+        } else {
+            this.showWidgetStatus(widgetId, action);
+        }
+    }
+
+    clearWidgetStatus(widgetId: string) {
+        // any status but FATAL, ERROR, WARNING or INFO will lead to a clear of the status
+        this.showWidgetStatus(widgetId, { kind: ServerStatusAction.KIND, message: '', severity: 'CLEAR' });
+    }
+
+    showWidgetStatus(widgetId: string, status: ServerStatusAction): void {
+        // remove any pending timeout
+        const pendingTimeout = this.widgetStatusTimeouts.get(widgetId);
+        if (pendingTimeout) {
+            window.clearTimeout(pendingTimeout);
+            this.widgetStatusTimeouts.delete(widgetId);
+        }
+
+        // update status
         const widget = this.widgetManager.getWidgets(this.diagramManager.id).find(w => w.id === widgetId);
         if (widget instanceof DiagramWidget) {
             widget.setStatus(status);
         }
 
-        if (status.severity !== "NONE") {
-            const { details, timeout } = isGLSPServerStatusAction(status) ? status : { details: undefined, timeout: -1 };
-            if (details) {
-                switch (status.severity) {
-                    case 'ERROR':
-                        this.messageService.error(status.message, SHOW_DETAILS_LABEL)
-                            .then(result => this.showDetailsOrClearStatus(result, status, details, widgetId));
-                        break;
-                    case 'WARNING':
-                        this.messageService.warn(status.message, SHOW_DETAILS_LABEL)
-                            .then(result => this.showDetailsOrClearStatus(result, status, details, widgetId));
-                        break;
-                    case 'INFO':
-                        this.messageService.info(status.message, SHOW_DETAILS_LABEL)
-                            .then(result => this.showDetailsOrClearStatus(result, status, details, widgetId));
-                        break;
-                }
-            } else {
-                switch (status.severity) {
-                    case 'ERROR':
-                        this.messageService.error(status.message, { timeout });
-                        break;
-                    case 'WARNING':
-                        this.messageService.warn(status.message, { timeout });
-                        break;
-                    case 'INFO':
-                        this.messageService.info(status.message, { timeout });
-                        break;
-                }
-            }
-
-            if (timeout && timeout >= 0) {
-                window.setTimeout(() => this.clearStatus(widgetId), timeout);
-            }
+        // check for any timeouts
+        const statusTimeout = isGLSPServerStatusAction(status) ? status.timeout : -1;
+        if (statusTimeout > 0) {
+            const newTimeout = window.setTimeout(() => this.clearWidgetStatus(widgetId), statusTimeout);
+            this.widgetStatusTimeouts.set(widgetId, newTimeout);
         }
     }
 
-    protected showDetailsOrClearStatus(result: string | undefined, status: ServerStatusAction, details: string, widgetId: string) {
-        if (result === SHOW_DETAILS_LABEL) {
-            showDialog(status.message, details).then(() => this.clearStatus(widgetId));
+    // Message
+
+    showMessage(widgetId: string, action: ServerMessageAction): void {
+        if (this.isClear(action.severity)) {
+            this.clearServerMessages(widgetId);
         } else {
-            this.clearStatus(widgetId);
+            this.showServerMessage(widgetId, action);
         }
     }
 
-    clearStatus(widgetId: string) {
-        this.showStatus(widgetId, { kind: ServerStatusAction.KIND, message: '', severity: 'NONE' });
+    clearServerMessages(widgetId: string) {
+        const widgetMessages = this.widgetMessages.get(widgetId) || [];
+        widgetMessages.forEach(messageId => this.clearServerMessage(widgetId, messageId));
+    }
+
+    clearServerMessage(widgetId: string, messageId: string) {
+        remove(this.widgetMessages.get(widgetId) || [], messageId);
+        this.notificationManager.clear(messageId);
+    }
+
+    showServerMessage(widgetId: string, action: ServerMessageAction) {
+        const widget = this.widgetManager.getWidgets(this.diagramManager.id).find(w => w.id === widgetId);
+        const uri = widget instanceof DiagramWidget ? widget.uri.toString() : '';
+
+        const type = this.toMessageType(action.severity);
+        const text = action.message;
+        const details = action.details;
+        const timeout = action.timeout;
+        const options = { timeout, uri } as GLSPMessageOptions;
+        const actions = details ? [SHOW_DETAILS_LABEL] : [];
+        const message: Message = { type, text, actions, options };
+        const messageId = this.createMessageId(message);
+
+        const clearMessageOnClose: (value?: string) => void = result => this.clearServerMessage(widgetId, messageId);
+
+        const onClose: (value?: string) => void = details
+            ? result => this.showDetailsOrClearMessage(result, text, details, clearMessageOnClose)
+            : clearMessageOnClose;
+        switch (message.type) {
+            case MessageType.Error:
+                this.addServerMessage(widgetId, messageId);
+                this.messageService.error(message.text, message.options, ...message.actions).then(onClose);
+                break;
+            case MessageType.Warning:
+                this.addServerMessage(widgetId, messageId);
+                this.messageService.warn(message.text, message.options, ...message.actions).then(onClose);
+                break;
+            case MessageType.Info:
+                this.addServerMessage(widgetId, messageId);
+                this.messageService.info(message.text, message.options, ...message.actions).then(onClose);
+                break;
+        }
+    }
+
+    addServerMessage(widgetId: string, messageId: string) {
+        const widgetMessages = this.widgetMessages.get(widgetId) || [];
+        widgetMessages.push(messageId);
+        this.widgetMessages.set(widgetId, widgetMessages);
+    }
+
+    protected showDetailsOrClearMessage(result: string | undefined, text: string, details: string, onClose: (value?: string) => void) {
+        if (result === SHOW_DETAILS_LABEL) {
+            showDialog(text, details).then(() => onClose());
+        } else {
+            onClose();
+        }
+    }
+
+    toMessageType(severity: string) {
+        switch (severity) {
+            case 'ERROR':
+                return MessageType.Error;
+            case 'WARNING':
+                return MessageType.Warning;
+            case 'INFO':
+                return MessageType.Info;
+        }
+        return MessageType.Log;
+    }
+
+    isClear(severity: string) {
+        return severity === 'NONE';
+    }
+
+    createMessageId(message: Message) {
+        return this.notificationManager.getMessageId(message);
     }
 
     sendMessage(message: ActionMessage) {

--- a/src/browser/frontend-module.ts
+++ b/src/browser/frontend-module.ts
@@ -15,6 +15,7 @@
  ********************************************************************************/
 import { bindContributionProvider, CommandContribution, MenuContribution } from "@theia/core";
 import { FrontendApplicationContribution, KeybindingContribution } from "@theia/core/lib/browser";
+import { NotificationManager } from "@theia/messages/lib/browser/notifications-manager";
 import { ContainerModule } from "inversify";
 import { TheiaContextMenuService } from "sprotty-theia/lib/sprotty/theia-sprotty-context-menu-service";
 
@@ -23,13 +24,14 @@ import {
     GLSPDiagramKeybindingContribution,
     GLSPDiagramMenuContribution
 } from "./diagram/glsp-diagram-commands";
+import { GLSPNotificationManager } from "./diagram/glsp-notification-manager";
 import { GLSPTheiaSprottyConnector } from "./diagram/glsp-theia-sprotty-connector";
 import { GLSPClientFactory } from "./language/glsp-client";
 import { GLSPClientContribution } from "./language/glsp-client-contribution";
 import { GLSPClientProvider, GLSPClientProviderImpl } from "./language/glsp-client-provider";
 import { GLSPFrontendContribution } from "./language/glsp-frontend-contribution";
 
-export default new ContainerModule(bind => {
+export default new ContainerModule((bind, unbind, isBound, rebind) => {
     bind(GLSPClientFactory).toSelf().inSingletonScope();
 
     bindContributionProvider(bind, GLSPClientContribution);
@@ -45,4 +47,12 @@ export default new ContainerModule(bind => {
     bind(KeybindingContribution).to(GLSPDiagramKeybindingContribution).inSingletonScope();
 
     bind(TheiaContextMenuService).toSelf().inSingletonScope();
+
+    bind(GLSPNotificationManager).toSelf().inSingletonScope();
+
+    if (isBound(NotificationManager)) {
+        rebind(NotificationManager).toService(GLSPNotificationManager);
+    } else {
+        bind(NotificationManager).toService(GLSPNotificationManager);
+    }
 });

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -21,6 +21,7 @@ export * from './diagram/glsp-diagram-manager';
 export * from './diagram/glsp-diagram-widget';
 export * from './diagram/glsp-theia-diagram-server';
 export * from './diagram/glsp-theia-sprotty-connector';
+export * from './diagram/glsp-notification-manager';
 // language export
 export * from './language/glsp-client';
 export * from './language/glsp-client-contribution';

--- a/yarn.lock
+++ b/yarn.lock
@@ -117,7 +117,7 @@
   dependencies:
     "@phosphor/algorithm" "^1.2.0"
 
-"@phosphor/widgets@^1.5.0":
+"@phosphor/widgets@^1.5.0", "@phosphor/widgets@^1.9.3":
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/@phosphor/widgets/-/widgets-1.9.3.tgz#b8b7ad69fd7cc7af8e8c312ebead0e0965a4cefd"
   integrity sha512-61jsxloDrW/+WWQs8wOgsS5waQ/MSsXBuhONt0o6mtdeL93HVz7CYO5krOoot5owammfF6oX1z0sDaUYIYgcPA==
@@ -169,6 +169,22 @@
     semver "^5.4.1"
     write-json-file "^2.2.0"
 
+"@theia/application-package@0.17.0-next.9457f808":
+  version "0.17.0-next.9457f808"
+  resolved "https://registry.yarnpkg.com/@theia/application-package/-/application-package-0.17.0-next.9457f808.tgz#10f7f8040b980287302393f2d2cbdc2c4081bb2b"
+  integrity sha512-TXVKNXngqvYk5/Ce2BShusWf5UyPvSMfAshgsVJQfSypSLGGDMtIvhF1fq487rfXkBjwIRDOmUXx2AP5KvVVvg==
+  dependencies:
+    "@types/fs-extra" "^4.0.2"
+    "@types/request" "^2.0.3"
+    "@types/semver" "^5.4.0"
+    "@types/write-json-file" "^2.2.1"
+    changes-stream "^2.2.0"
+    fs-extra "^4.0.2"
+    is-electron "^2.1.0"
+    request "^2.82.0"
+    semver "^5.4.1"
+    write-json-file "^2.2.0"
+
 "@theia/core@0.13.0-next.5c02a25d", "@theia/core@next":
   version "0.13.0-next.5c02a25d"
   resolved "https://registry.yarnpkg.com/@theia/core/-/core-0.13.0-next.5c02a25d.tgz#283360562af0def1e989e98accb6dc6bb1cfccef"
@@ -192,6 +208,53 @@
     "@types/yargs" "^11.1.0"
     ajv "^6.5.3"
     body-parser "^1.17.2"
+    es6-promise "^4.2.4"
+    express "^4.16.3"
+    file-icons-js "^1.0.3"
+    font-awesome "^4.7.0"
+    fs-extra "^4.0.2"
+    fuzzy "^0.1.3"
+    inversify "^5.0.1"
+    lodash.debounce "^4.0.8"
+    lodash.throttle "^4.1.1"
+    nsfw "^1.2.2"
+    perfect-scrollbar "^1.3.0"
+    react "^16.4.1"
+    react-dom "^16.4.1"
+    react-virtualized "^9.20.0"
+    reconnecting-websocket "^4.2.0"
+    reflect-metadata "^0.1.10"
+    route-parser "^0.0.5"
+    vscode-languageserver-types "^3.15.0-next"
+    vscode-uri "^1.0.8"
+    vscode-ws-jsonrpc "^0.1.1"
+    ws "^7.1.2"
+    yargs "^11.1.0"
+
+"@theia/core@0.17.0-next.9457f808":
+  version "0.17.0-next.9457f808"
+  resolved "https://registry.yarnpkg.com/@theia/core/-/core-0.17.0-next.9457f808.tgz#ca680cbdf41ab30a26012533f114a7bde9417f32"
+  integrity sha512-V55vzncUwe2dokXWlXmU0yKfE2FbE70IfpiInShMee0uoqCUj0GT5jjlOUJuJ1lye9kFDiCCnxG0xRdDclL6AA==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    "@phosphor/widgets" "^1.9.3"
+    "@primer/octicons-react" "^9.0.0"
+    "@theia/application-package" "0.17.0-next.9457f808"
+    "@types/body-parser" "^1.16.4"
+    "@types/cookie" "^0.3.3"
+    "@types/express" "^4.16.0"
+    "@types/fs-extra" "^4.0.2"
+    "@types/lodash.debounce" "4.0.3"
+    "@types/lodash.throttle" "^4.1.3"
+    "@types/react" "^16.4.1"
+    "@types/react-dom" "^16.0.6"
+    "@types/react-virtualized" "^9.18.3"
+    "@types/route-parser" "^0.1.1"
+    "@types/ws" "^5.1.2"
+    "@types/yargs" "^11.1.0"
+    ajv "^6.5.3"
+    body-parser "^1.17.2"
+    cookie "^0.4.0"
     es6-promise "^4.2.4"
     express "^4.16.3"
     file-icons-js "^1.0.3"
@@ -275,6 +338,17 @@
     "@theia/filesystem" "0.13.0-next.5c02a25d"
     "@theia/navigator" "0.13.0-next.5c02a25d"
     "@theia/workspace" "0.13.0-next.5c02a25d"
+
+"@theia/messages@next":
+  version "0.17.0-next.9457f808"
+  resolved "https://registry.yarnpkg.com/@theia/messages/-/messages-0.17.0-next.9457f808.tgz#4320ff9da8ad80593353fd6904c38a86566ecd96"
+  integrity sha512-VJ9vRtZBDp6XNJ6CNaOZz/3qqNPj3OBY6rm7O1bkx8C3eazuDVZT4Kr3KNk7g2hqFfjdMB92SP3NacFNjfnVGw==
+  dependencies:
+    "@theia/core" "0.17.0-next.9457f808"
+    lodash.throttle "^4.1.1"
+    markdown-it "^8.4.0"
+    react-perfect-scrollbar "^1.5.3"
+    ts-md5 "^1.2.2"
 
 "@theia/monaco@next":
   version "0.13.0-next.5c02a25d"
@@ -392,6 +466,11 @@
   integrity sha512-4r8qa0quOvh7lGD0pre62CAb1oni1OO6ecJLGCezTmhQ8Fz50Arx9RUszryR8KlgK6avuSXvviL6yWyViQABOg==
   dependencies:
     "@types/node" "*"
+
+"@types/cookie@^0.3.3":
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.3.3.tgz#85bc74ba782fb7aa3a514d11767832b0e3bc6803"
+  integrity sha512-LKVP3cgXBT9RYj+t+9FDKwS5tdI+rPBXaNSkma7hvqy35lc7mAokC2zsqWJH0LaqIt3B962nuYI77hsJoT1gow==
 
 "@types/events@*":
   version "3.0.0"
@@ -906,7 +985,7 @@ cookie-signature@1.0.6:
   resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.0.6.tgz#e303a882b342cc3ee8ca513a79999734dab3ae2c"
   integrity sha1-4wOogrNCzD7oylE6eZmXNNqzriw=
 
-cookie@0.4.0:
+cookie@0.4.0, cookie@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.0.tgz#beb437e7022b3b6d49019d088665303ebe9c14ba"
   integrity sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==
@@ -1078,6 +1157,11 @@ end-of-stream@^1.0.0, end-of-stream@^1.1.0:
   integrity sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
   dependencies:
     once "^1.4.0"
+
+entities@~1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.2.tgz#bdfa735299664dfafd34529ed4f8522a275fea56"
+  integrity sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==
 
 es6-promise@^4.2.4:
   version "4.2.8"
@@ -1705,6 +1789,13 @@ lcid@^2.0.0:
   dependencies:
     invert-kv "^2.0.0"
 
+linkify-it@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-2.2.0.tgz#e3b54697e78bf915c70a38acd78fd09e0058b1cf"
+  integrity sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==
+  dependencies:
+    uc.micro "^1.0.1"
+
 locate-path@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-2.0.0.tgz#2b568b265eec944c6d9c0de9c3dbbbca0354cd8e"
@@ -1761,6 +1852,22 @@ map-age-cleaner@^0.1.1:
   integrity sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==
   dependencies:
     p-defer "^1.0.0"
+
+markdown-it@^8.4.0:
+  version "8.4.2"
+  resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-8.4.2.tgz#386f98998dc15a37722aa7722084f4020bdd9b54"
+  integrity sha512-GcRz3AWTqSUphY3vsUqQSFMbgR38a4Lh3GWlHRh/7MRwz8mcu9n2IO7HOh+bXHrR9kOPDl5RNCaEsrneb+xhHQ==
+  dependencies:
+    argparse "^1.0.7"
+    entities "~1.1.1"
+    linkify-it "^2.0.0"
+    mdurl "^1.0.1"
+    uc.micro "^1.0.5"
+
+mdurl@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/mdurl/-/mdurl-1.0.1.tgz#fe85b2ec75a59037f2adfec100fd6c601761152e"
+  integrity sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=
 
 media-typer@0.3.0:
   version "0.3.0"
@@ -2121,6 +2228,11 @@ perfect-scrollbar@^1.3.0:
   resolved "https://registry.yarnpkg.com/perfect-scrollbar/-/perfect-scrollbar-1.4.0.tgz#5d014ef9775e1f43058a1dbae9ed1daf0e7091f1"
   integrity sha512-/2Sk/khljhdrsamjJYS5NjrH+GKEHEwh7zFSiYyxROyYKagkE4kSn2zDQDRTOMo8mpT2jikxx6yI1dG7lNP/hw==
 
+perfect-scrollbar@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/perfect-scrollbar/-/perfect-scrollbar-1.5.0.tgz#821d224ed8ff61990c23f26db63048cdc75b6b83"
+  integrity sha512-NrNHJn5mUGupSiheBTy6x+6SXCFbLlm8fVZh9moIzw/LgqElN5q4ncR4pbCBCYuCJ8Kcl9mYM0NgDxvW+b4LxA==
+
 performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
@@ -2289,6 +2401,14 @@ react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
+
+react-perfect-scrollbar@^1.5.3:
+  version "1.5.8"
+  resolved "https://registry.yarnpkg.com/react-perfect-scrollbar/-/react-perfect-scrollbar-1.5.8.tgz#380959387a325c5c9d0268afc08b3f73ed5b3078"
+  integrity sha512-bQ46m70gp/HJtiBOF3gRzBISSZn8FFGNxznTdmTG8AAwpxG1bJCyn7shrgjEvGSQ5FJEafVEiosY+ccER11OSA==
+  dependencies:
+    perfect-scrollbar "^1.5.0"
+    prop-types "^15.6.1"
 
 react-virtualized@^9.20.0:
   version "9.21.2"
@@ -2739,6 +2859,11 @@ trash@^4.0.1:
     uuid "^3.1.0"
     xdg-trashdir "^2.1.1"
 
+ts-md5@^1.2.2:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/ts-md5/-/ts-md5-1.2.7.tgz#b76471fc2fd38f0502441f6c3b9494ed04537401"
+  integrity sha512-emODogvKGWi1KO1l9c6YxLMBn6CEH3VrH5mVPIyOtxBG52BvV4jP3GWz6bOZCz61nLgBc3ffQYE4+EHfCD+V7w==
+
 tslib@^1.8.0, tslib@^1.8.1:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
@@ -2794,6 +2919,11 @@ typescript@3.6.4:
   version "3.6.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.4.tgz#b18752bb3792bc1a0281335f7f6ebf1bbfc5b91d"
   integrity sha512-unoCll1+l+YK4i4F8f22TaNVPRHcD9PA3yCuZ8g5e0qGqlVlJ/8FSateOLLSagn+Yg5+ZwuPkL8LFUc0Jcvksg==
+
+uc.micro@^1.0.1, uc.micro@^1.0.5:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/uc.micro/-/uc.micro-1.0.6.tgz#9c411a802a409a91fc6cf74081baba34b24499ac"
+  integrity sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==
 
 universalify@^0.1.0:
   version "0.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -25,10 +25,10 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
-"@eclipse-glsp/client@next":
-  version "0.8.0-next.2be8d77"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp/client/-/client-0.8.0-next.2be8d77.tgz#b2c24333df2d6ad2fd30272a1c5402510d3c80ac"
-  integrity sha512-mdOgUtupj3TFW25WB+ov874RvPI+HRvFWRhDUfhlB1V5bXN6yTz3Kxsqt66vUeDm3IiOUlv/94Qipmdx7jS1eA==
+"@eclipse-glsp/client@0.8.0-next.7324d57":
+  version "0.8.0-next.7324d57"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp/client/-/client-0.8.0-next.7324d57.tgz#f74c8919ed0adb7dccd8fb5e267bb1391259d392"
+  integrity sha512-OJzWpRo5JPjFvDfIAjZN/XNzk73J40hLfUzLhgjEa3nM7MKex0KOfrmYSjasCw2e2CFAT2J7m5V9CqZzS0mnyQ==
   dependencies:
     autocompleter "^4.0.2"
     sprotty next


### PR DESCRIPTION
- Add new ServerMessageAction handling in glsp-theia-sprotty connector
- Disentangle handling of status with handling of messages
- Provide custom notification manager to generate unique ids per widget

- Fixes eclipse-glsp/glsp/issues/48



Please note this change belongs to this group:
- https://github.com/eclipse-glsp/glsp-server/pull/51
- https://github.com/eclipse-glsp/glsp-examples/pull/40
- https://github.com/eclipse-glsp/glsp-client/pull/46
- https://github.com/eclipse-glsp/glsp/pull/49