### PR TITLE
Create new TheiaContextMenuService per widget

### DIFF
--- a/src/browser/diagram/glsp-diagram-widget.ts
+++ b/src/browser/diagram/glsp-diagram-widget.ts
@@ -34,7 +34,6 @@ import { DiagramWidget, DiagramWidgetOptions, TheiaSprottyConnector } from "spro
 
 import { DirtyStateNotifier, GLSPTheiaDiagramServer } from "./glsp-theia-diagram-server";
 
-
 export class GLSPDiagramWidget extends DiagramWidget implements SaveableSource {
 
     protected copyPasteHandler?: ICopyPasteHandler;

--- a/src/browser/diagram/glsp-theia-context-menu-service.ts
+++ b/src/browser/diagram/glsp-theia-context-menu-service.ts
@@ -1,0 +1,28 @@
+/********************************************************************************
+ * Copyright (c) 2020 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+import { GLSP_TYPES, IActionDispatcher, TYPES } from "@eclipse-glsp/client";
+import { Container } from "inversify";
+import { TheiaContextMenuService } from "sprotty-theia/lib/sprotty/theia-sprotty-context-menu-service";
+
+export const TheiaContextMenuServiceFactory = Symbol('TheiaContextMenuServiceFactory');
+
+export function connectTheiaDiagramService(container: Container, contextMenuServiceFactory: () => TheiaContextMenuService) {
+    const contextMenuService = contextMenuServiceFactory();
+    container.bind(GLSP_TYPES.IContextMenuService).toConstantValue(contextMenuService);
+    if (contextMenuService instanceof TheiaContextMenuService) {
+        contextMenuService.connect(container.get<IActionDispatcher>(TYPES.IActionDispatcher));
+    }
+}

--- a/src/browser/frontend-module.ts
+++ b/src/browser/frontend-module.ts
@@ -25,6 +25,7 @@ import {
     GLSPDiagramMenuContribution
 } from "./diagram/glsp-diagram-commands";
 import { GLSPNotificationManager } from "./diagram/glsp-notification-manager";
+import { TheiaContextMenuServiceFactory } from "./diagram/glsp-theia-context-menu-service";
 import { GLSPTheiaSprottyConnector } from "./diagram/glsp-theia-sprotty-connector";
 import { GLSPClientFactory } from "./language/glsp-client";
 import { GLSPClientContribution } from "./language/glsp-client-contribution";
@@ -46,7 +47,11 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
     bind(MenuContribution).to(GLSPDiagramMenuContribution).inSingletonScope();
     bind(KeybindingContribution).to(GLSPDiagramKeybindingContribution).inSingletonScope();
 
-    bind(TheiaContextMenuService).toSelf().inSingletonScope();
+    bind(TheiaContextMenuServiceFactory).toFactory(context => () => {
+        const container = context.container.createChild();
+        container.bind(TheiaContextMenuService).toSelf().inSingletonScope();
+        return container.get(TheiaContextMenuService);
+    });
 
     bind(GLSPNotificationManager).toSelf().inSingletonScope();
 

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -22,6 +22,7 @@ export * from './diagram/glsp-diagram-widget';
 export * from './diagram/glsp-theia-diagram-server';
 export * from './diagram/glsp-theia-sprotty-connector';
 export * from './diagram/glsp-notification-manager';
+export * from './diagram/glsp-theia-context-menu-service';
 // language export
 export * from './language/glsp-client';
 export * from './language/glsp-client-contribution';


### PR DESCRIPTION
Otherwise the last opened GLSP widget connects to the same
TheiaContextMenuService over and over again so that all context menu
actions are performed in the action dispatcher of the last widget.

To make this more convenient for clients, we provide a factory and a
function for hooking up the context menu service.

https://github.com/eclipse-glsp/glsp/issues/57