### PR TITLE
Support navigation from Theia to diagram elements and vice versa

### DIFF
--- a/src/browser/diagram/glsp-theia-context-menu-service.ts
+++ b/src/browser/diagram/glsp-theia-context-menu-service.ts
@@ -19,7 +19,7 @@ import { TheiaContextMenuService } from "sprotty-theia/lib/sprotty/theia-sprotty
 
 export const TheiaContextMenuServiceFactory = Symbol('TheiaContextMenuServiceFactory');
 
-export function connectTheiaDiagramService(container: Container, contextMenuServiceFactory: () => TheiaContextMenuService) {
+export function connectTheiaContextMenuService(container: Container, contextMenuServiceFactory: () => TheiaContextMenuService) {
     const contextMenuService = contextMenuServiceFactory();
     container.bind(GLSP_TYPES.IContextMenuService).toConstantValue(contextMenuService);
     if (contextMenuService instanceof TheiaContextMenuService) {

--- a/src/browser/frontend-module.ts
+++ b/src/browser/frontend-module.ts
@@ -32,6 +32,8 @@ import { GLSPClientFactory } from "./language/glsp-client";
 import { GLSPClientContribution } from "./language/glsp-client-contribution";
 import { GLSPClientProvider, GLSPClientProviderImpl } from "./language/glsp-client-provider";
 import { GLSPFrontendContribution } from "./language/glsp-frontend-contribution";
+import { TheiaNavigateToTargetHandler } from "./theia-navigate-to-target-handler";
+import { TheiaOpenerOptionsNavigationService } from "./theia-opener-options-navigation-service";
 
 export default new ContainerModule((bind, unbind, isBound, rebind) => {
     bind(GLSPClientFactory).toSelf().inSingletonScope();
@@ -66,4 +68,7 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
         container.bind(TheiaMarkerManager).toSelf().inSingletonScope();
         return container.get(TheiaMarkerManager);
     });
+
+    bind(TheiaNavigateToTargetHandler).toSelf().inSingletonScope();
+    bind(TheiaOpenerOptionsNavigationService).toSelf().inSingletonScope();
 });

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -15,6 +15,9 @@
  ********************************************************************************/
 
 export * from './theia-command-palette';
+export * from './theia-navigate-to-target-handler';
+export * from './theia-opener-options-navigation-service';
+
 // diagram export
 export * from './diagram/glsp-diagram-client';
 export * from './diagram/glsp-diagram-manager';
@@ -23,6 +26,7 @@ export * from './diagram/glsp-theia-diagram-server';
 export * from './diagram/glsp-theia-sprotty-connector';
 export * from './diagram/glsp-notification-manager';
 export * from './diagram/glsp-theia-context-menu-service';
+
 // language export
 export * from './language/glsp-client';
 export * from './language/glsp-client-contribution';

--- a/src/browser/theia-navigate-to-target-handler.ts
+++ b/src/browser/theia-navigate-to-target-handler.ts
@@ -1,0 +1,38 @@
+/********************************************************************************
+ * Copyright (c) 2020 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+import { Args, ExternalNavigateToTargetHandler } from "@eclipse-glsp/client/lib";
+import { open, OpenerService } from "@theia/core/lib/browser/opener-service";
+import URI from "@theia/core/lib/common/uri";
+import { inject, injectable } from "inversify";
+
+@injectable()
+export class TheiaNavigateToTargetHandler extends ExternalNavigateToTargetHandler {
+    static JSON_OPENER_OPTIONS = 'jsonOpenerOptions';
+    /**
+     * Opens the specified URI in Theia using Theia's opener service.
+     *
+     * If `args` contain a property `jsonOpenerOptions`, the string of this property will be parsed as JSON
+     * and merged into the opener options. This allows GLSP servers to pass additional opener options, such
+     * as a selection, etc.
+     */
+    @inject(OpenerService) protected readonly openerService: OpenerService;
+    async navigateTo(uri: string, args?: Args): Promise<void> {
+        if (args && args[TheiaNavigateToTargetHandler.JSON_OPENER_OPTIONS]) {
+            args = { args, ...JSON.parse(args[TheiaNavigateToTargetHandler.JSON_OPENER_OPTIONS].toString()) };
+        }
+        await open(this.openerService, new URI(uri), { ...args });
+    }
+}

--- a/src/browser/theia-opener-options-navigation-service.ts
+++ b/src/browser/theia-opener-options-navigation-service.ts
@@ -1,0 +1,97 @@
+/********************************************************************************
+ * Copyright (c) 2020 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+import { NavigateToTargetAction, NavigationTarget } from "@eclipse-glsp/client/lib";
+import { OpenerOptions } from "@theia/core/lib/browser";
+import { Range } from "@theia/editor/lib/browser";
+import { injectable } from "inversify";
+
+/**
+ * Service for translating `OpenerOptions` into a `NavigateToTargetAction`.
+ *
+ * This service is typically used to determine requested selections from Theia
+ * opener options on open or reveal of a diagram widget. Diagram widgets can
+ * then dispatch the determined diagram navigation actions once the widget is
+ * initialized.
+ *
+ * This service will forward the `selection` property of the `OpenerOptions`
+ * in the form of arguments in the issued `NavigateToTargetAction` as follows:
+ *   *(a)* the property `elementIds: string[]` as element ids
+ *   *(b)* `start` with `line: number` and `character: number`
+ *   *(c)* any simple-typed properties that are direct properties of `selection`
+ */
+@injectable()
+export class TheiaOpenerOptionsNavigationService {
+    determineNavigations(uri: string, options?: OpenerOptions): NavigateToTargetAction[] {
+        if (OptionsWithSelection.is(options)) {
+            const selection = options.selection;
+            const navigationTarget = { uri };
+            Object.keys(selection).forEach(key => {
+                const value = selection[key];
+                if (typeof value !== 'object') {
+                    NavigationTarget.addArgument(navigationTarget, key, value);
+                }
+            });
+            if (SelectionWithElementIds.is(selection)) {
+                NavigationTarget.setElementIds(navigationTarget, selection.elementIds);
+            }
+            if (Range.is(selection)) {
+                NavigationTarget.setTextPosition(navigationTarget, {
+                    line: selection.start.line, character: selection.start.character
+                });
+            }
+            return [new NavigateToTargetAction(navigationTarget)];
+        }
+        return [];
+    }
+}
+
+export interface OptionsWithSelection {
+    readonly selection: any;
+}
+
+export namespace OptionsWithSelection {
+    export function is(options: OpenerOptions | undefined): options is OptionsWithSelection {
+        return options !== undefined && 'selection' in options;
+    }
+    export function elementId(options: OpenerOptions | undefined): string[] | undefined {
+        if (!OptionsWithSelection.is(options)) {
+            return undefined;
+        }
+        if (!SelectionWithElementIds.is(options.selection)) {
+            return undefined;
+        }
+        return options.selection.elementIds;
+    }
+}
+
+export interface SelectionWithElementIds {
+    readonly elementIds: string[];
+}
+
+export namespace SelectionWithElementIds {
+    export function is(selection: any | undefined): selection is SelectionWithElementIds {
+        return selection !== undefined && 'elementIds' in selection;
+    }
+    export function createRange(elementIds: string[]): Range & SelectionWithElementIds {
+        return { elementIds, start: { line: -1, character: -1 }, end: { line: -1, character: -1 } };
+    }
+}
+
+export namespace SelectionWithRange {
+    export function is(selection: any | undefined): selection is Range {
+        return Range.is(selection);
+    }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -26,9 +26,9 @@
     regenerator-runtime "^0.13.2"
 
 "@eclipse-glsp/client@next":
-  version "0.8.0-next.b11cde2"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp/client/-/client-0.8.0-next.b11cde2.tgz#1486b988983aaac9fdd9879fb7ffa57f1b9061ea"
-  integrity sha512-DEJA+dyIFXcgoOlEFO6fR3YJ2oRnthHDXJrLiqx/dG5ilwKdpeVbn9wwVSc5Uax42a9raUQ2gmpdfumhhXleeg==
+  version "0.8.0-next.155bf6e"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp/client/-/client-0.8.0-next.155bf6e.tgz#5149b83e15425653316aaef730216d99fc19ea5a"
+  integrity sha512-B3bvsmI9jxHO6zgXjcIhj2XR6D8UER27CkpnEsCO2sXkEq4c8974sBr291Qtc86WdZgxHBe5ukjlFQHrJUCKyA==
   dependencies:
     autocompleter "5.1.0"
     sprotty next


### PR DESCRIPTION
This change provides a Theia-specific implementation for the external navigation handler introduced in 
https://github.com/eclipse-glsp/glsp-client/pull/61. Also it puts the code for selecting elements based on opener options after opening a GLSP widget into an own handler that can be rebound for customizations if necessary.

https://github.com/eclipse-glsp/glsp/issues/69