### PR TITLE
Error messages from the server are not displayed properly

### DIFF
--- a/css/theia-dialogs.css
+++ b/css/theia-dialogs.css
@@ -1,0 +1,5 @@
+.scroll-div {
+    /** scrollable div, used e.g. in a Theia ConfirmDialog */
+    max-height: 260px;
+    overflow: auto;
+}

--- a/src/browser/diagram/glsp-theia-sprotty-connector.ts
+++ b/src/browser/diagram/glsp-theia-sprotty-connector.ts
@@ -218,5 +218,20 @@ export class GLSPTheiaSprottyConnector implements TheiaSprottyConnector, GLSPThe
 }
 
 export function showDialog(title: string, msg: string) {
-    return new ConfirmDialog({ title, msg }).open();
+    const wrappedMsg = wrapMessage(msg);
+    return new ConfirmDialog({ title, msg: wrappedMsg }).open();
+}
+
+/**
+ * Wraps the given message in a pre-formatted,
+ * scrollable div.
+ * @param msg
+ */
+function wrapMessage(msg: string) {
+    const scrollDiv = document.createElement('div');
+    scrollDiv.className = 'scroll-div';
+    const pre = document.createElement('pre');
+    pre.textContent = msg;
+    scrollDiv.appendChild(pre);
+    return scrollDiv;
 }

--- a/src/browser/language/glsp-client-contribution.ts
+++ b/src/browser/language/glsp-client-contribution.ts
@@ -14,6 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 import "../../../css/diagram.css";
+import "../../../css/theia-dialogs.css";
 import "../../../css/tool-palette.css";
 
 import { CommandRegistry, DisposableCollection, MaybePromise, MessageService } from "@theia/core";


### PR DESCRIPTION
- Wrap error messages in a &lt;pre&gt; tag
- Add a scrollable div around it, to support long stack traces

This fixes https://github.com/eclipse-glsp/glsp/issues/83