### PR TITLE
#87 Code adaptations to support new readonly mode

### DIFF
--- a/src/browser/diagram/glsp-diagram-layout-commands.ts
+++ b/src/browser/diagram/glsp-diagram-layout-commands.ts
@@ -285,7 +285,7 @@ export class GLSPLayoutCommandContribution implements CommandContribution {
             label: "Resize to " + label,
         }, new GLSPCommandHandler(this.shell, {
             actions: () => [new ResizeElementsAction([], dimension, f)],
-            isEnabled: context => context.get().selectedElementIds.length > 1
+            isEnabled: context => !context.isReadonly && context.get().selectedElementIds.length > 1
         }));
     }
 
@@ -296,7 +296,7 @@ export class GLSPLayoutCommandContribution implements CommandContribution {
             label: "Align " + label
         }, new GLSPCommandHandler(this.shell, {
             actions: () => [new AlignElementsAction([], alignment, f)],
-            isEnabled: context => context.get().selectedElementIds.length > 1
+            isEnabled: context => !context.isReadonly && context.get().selectedElementIds.length > 1
         }));
     }
 
@@ -354,22 +354,26 @@ export class GLSPLayoutKeybindingContribution implements KeybindingContribution 
         registry.registerKeybinding({
             command: GLSPLayoutCommands.ALIGN_LEFT,
             context: this.diagramKeybindingContext.id,
-            keybinding: 'alt+shift+left'
+            keybinding: 'alt+shift+left',
+            when: '!glspEditorIsReadonly && glspEditorHasMultipleSelection'
         });
         registry.registerKeybinding({
             command: GLSPLayoutCommands.ALIGN_RIGHT,
             context: this.diagramKeybindingContext.id,
-            keybinding: 'alt+shift+right'
+            keybinding: 'alt+shift+right',
+            when: '!glspEditorIsReadonly && glspEditorHasMultipleSelection'
         });
         registry.registerKeybinding({
             command: GLSPLayoutCommands.ALIGN_TOP,
             context: this.diagramKeybindingContext.id,
-            keybinding: 'alt+shift+up'
+            keybinding: 'alt+shift+up',
+            when: '!glspEditorIsReadonly && glspEditorHasMultipleSelection'
         });
         registry.registerKeybinding({
             command: GLSPLayoutCommands.ALIGN_BOTTOM,
             context: this.diagramKeybindingContext.id,
-            keybinding: 'alt+shift+down'
+            keybinding: 'alt+shift+down',
+            when: '!glspEditorIsReadonly && glspEditorHasMultipleSelection'
         });
     }
 }

--- a/src/browser/diagram/glsp-diagram-manager.ts
+++ b/src/browser/diagram/glsp-diagram-manager.ts
@@ -13,7 +13,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import { GLSPActionDispatcher } from "@eclipse-glsp/client";
+import { EditMode, GLSPActionDispatcher } from "@eclipse-glsp/client";
 import {
     FrontendApplicationContribution,
     NavigatableWidgetOptions,
@@ -80,13 +80,14 @@ export abstract class GLSPDiagramManager extends DiagramManager {
         throw Error('DiagramWidgetFactory needs DiagramWidgetOptions but got ' + JSON.stringify(options));
     }
 
-    protected createWidgetOptions(uri: URI, options?: WidgetOpenerOptions): DiagramWidgetOptions & NavigatableWidgetOptions {
-        return {
+    protected createWidgetOptions(uri: URI, options?: GLSPWidgetOpenerOptions): DiagramWidgetOptions & GLSPWidgetOptions {
+        return <DiagramWidgetOptions & GLSPWidgetOptions>{
             diagramType: this.diagramType,
             kind: 'navigatable',
             uri: uri.toString(true),
             iconClass: this.iconClass,
-            label: uri.path.base
+            label: uri.path.base,
+            editMode: options && options.editMode ? options.editMode : EditMode.EDITABLE
         };
     }
 
@@ -102,4 +103,12 @@ export abstract class GLSPDiagramManager extends DiagramManager {
     get diagramConnector(): GLSPTheiaSprottyConnector | undefined {
         return undefined;
     }
+}
+
+export interface GLSPWidgetOpenerOptions extends WidgetOpenerOptions {
+    editMode?: string;
+}
+
+export interface GLSPWidgetOptions extends NavigatableWidgetOptions {
+    editMode: string;
 }

--- a/src/browser/diagram/glsp-diagram-widget.ts
+++ b/src/browser/diagram/glsp-diagram-widget.ts
@@ -24,6 +24,7 @@ import {
     RequestModelAction,
     RequestTypeHintsAction,
     SaveModelAction,
+    SetEditModeAction,
     TYPES
 } from "@eclipse-glsp/client";
 import { Message } from "@phosphor/messaging/lib";
@@ -33,14 +34,15 @@ import { EditorPreferences } from "@theia/editor/lib/browser";
 import { Container } from "inversify";
 import { DiagramWidget, DiagramWidgetOptions, TheiaSprottyConnector } from "sprotty-theia";
 
+import { GLSPWidgetOpenerOptions, GLSPWidgetOptions } from "./glsp-diagram-manager";
 import { DirtyStateNotifier, GLSPTheiaDiagramServer } from "./glsp-theia-diagram-server";
 
 export class GLSPDiagramWidget extends DiagramWidget implements SaveableSource {
 
     protected copyPasteHandler?: ICopyPasteHandler;
     saveable = new SaveableGLSPModelSource(this.actionDispatcher, this.diContainer.get<ModelSource>(TYPES.ModelSource));
-
-    constructor(options: DiagramWidgetOptions, readonly widgetId: string, readonly diContainer: Container,
+    options: DiagramWidgetOptions & GLSPWidgetOptions;
+    constructor(options: DiagramWidgetOptions & GLSPWidgetOpenerOptions, readonly widgetId: string, readonly diContainer: Container,
         readonly editorPreferences: EditorPreferences, readonly connector?: TheiaSprottyConnector) {
         super(options, widgetId, diContainer, connector);
         this.updateSaveable();
@@ -70,10 +72,12 @@ export class GLSPDiagramWidget extends DiagramWidget implements SaveableSource {
         this.actionDispatcher.dispatch(new RequestModelAction({
             sourceUri: this.uri.path.toString(),
             needsClientLayout: `${this.viewerOptions.needsClientLayout}`,
-            ...this.options
+            ... this.options
         }));
+
         this.actionDispatcher.dispatch(new RequestTypeHintsAction(this.options.diagramType));
         this.actionDispatcher.dispatch(new EnableToolPaletteAction());
+        this.actionDispatcher.dispatch(new SetEditModeAction(this.options.editMode));
     }
 
     protected onAfterAttach(msg: Message): void {

--- a/yarn.lock
+++ b/yarn.lock
@@ -25,10 +25,10 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
-"@eclipse-glsp/client@next":
-  version "0.8.0-next.45707bf"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp/client/-/client-0.8.0-next.45707bf.tgz#b3f655f1865faf334554399e8ffcd77e135e0659"
-  integrity sha512-XglhlSLSUBBYE3j1KDOHBd3rm/BtKfSYjuwjMkJWD8cCOkkwlX7wNV1JeSaLf4njQurIJdQmsU5LjImV8PhHXA==
+"@eclipse-glsp/client@0.8.0-next.e555d60", "@eclipse-glsp/client@next":
+  version "0.8.0-next.e555d60"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp/client/-/client-0.8.0-next.e555d60.tgz#647cf27b3dc12efe248ef3307bac968eef17c0b8"
+  integrity sha512-EAwQ/rZk1yQ7o7cCxZ339SeRnS9A+vOjdXCD5YE67owketMUyr33GAuIlL/FXS3tCIVbBIC+K1DxySrB7A/0Jw==
   dependencies:
     autocompleter "5.1.0"
     sprotty next


### PR DESCRIPTION
-Introduce custom WidgetOptions to set the editmode & dispatch corresponding action on initialize
- Disable commands with edit-function in readonly mode
Remove remains of old dirty-state handling approach (Resolves eclipse-glsp/glsp/issues/86)

Part of eclipse-glsp/glsp/issues/87