### PR TITLE
#66, #72: Refactor code for easier customization

### DIFF
--- a/examples/workspace/example1.wf
+++ b/examples/workspace/example1.wf
@@ -10,24 +10,23 @@
           "id": "task0_header",
           "children": [
             {
-              "commandId": "simulate-command",
               "id": "task0_icon",
               "children": [
                 {
                   "id": "task0_ticon",
                   "type": "label:icon",
                   "position": {
-                    "x": 7.65625,
-                    "y": 4.796875
+                    "x": 7.4921875,
+                    "y": 5.0
                   },
                   "size": {
-                    "width": 16.6875,
-                    "height": 22.40625
+                    "width": 17.015625,
+                    "height": 22.0
                   },
                   "text": "M",
                   "alignment": {
                     "x": 8.34375,
-                    "y": 18.40625
+                    "y": 18.0
                   }
                 }
               ],
@@ -51,16 +50,16 @@
               "type": "label:heading",
               "position": {
                 "x": 38.0,
-                "y": 9.796875
+                "y": 10.0
               },
               "size": {
                 "width": 48.90625,
-                "height": 22.40625
+                "height": 22.0
               },
               "text": "Push",
               "alignment": {
                 "x": 24.453125,
-                "y": 18.40625
+                "y": 18.0
               }
             }
           ],
@@ -96,24 +95,23 @@
           "id": "task1_header",
           "children": [
             {
-              "commandId": "simulate-command",
               "id": "task1_icon",
               "children": [
                 {
                   "id": "task1_ticon",
                   "type": "label:icon",
                   "position": {
-                    "x": 7.65625,
-                    "y": 4.796875
+                    "x": 7.4921875,
+                    "y": 5.0
                   },
                   "size": {
-                    "width": 16.6875,
-                    "height": 22.40625
+                    "width": 17.015625,
+                    "height": 22.0
                   },
                   "text": "M",
                   "alignment": {
                     "x": 8.34375,
-                    "y": 18.40625
+                    "y": 18.0
                   }
                 }
               ],
@@ -137,16 +135,16 @@
               "type": "label:heading",
               "position": {
                 "x": 38.0,
-                "y": 9.796875
+                "y": 10.0
               },
               "size": {
                 "width": 53.5625,
-                "height": 22.40625
+                "height": 22.0
               },
               "text": "RflWt",
               "alignment": {
                 "x": 26.109375,
-                "y": 18.40625
+                "y": 18.0
               }
             }
           ],
@@ -182,24 +180,23 @@
           "id": "task2_header",
           "children": [
             {
-              "commandId": "simulate-command",
               "id": "task2_icon",
               "children": [
                 {
                   "id": "task2_ticon",
                   "type": "label:icon",
                   "position": {
-                    "x": 7.65625,
-                    "y": 4.796875
+                    "x": 7.4921875,
+                    "y": 5.0
                   },
                   "size": {
-                    "width": 16.6875,
-                    "height": 22.40625
+                    "width": 17.015625,
+                    "height": 22.0
                   },
                   "text": "M",
                   "alignment": {
                     "x": 8.34375,
-                    "y": 18.40625
+                    "y": 18.0
                   }
                 }
               ],
@@ -223,16 +220,16 @@
               "type": "label:heading",
               "position": {
                 "x": 38.0,
-                "y": 9.796875
+                "y": 10.0
               },
               "size": {
-                "width": 62.8125,
-                "height": 22.40625
+                "width": 64.015625,
+                "height": 22.0
               },
               "text": "ChkTp",
               "alignment": {
-                "x": 31.109375,
-                "y": 18.40625
+                "x": 32.109375,
+                "y": 18.0
               }
             }
           ],
@@ -242,7 +239,7 @@
             "y": 5.0
           },
           "size": {
-            "width": 105.8125,
+            "width": 107.015625,
             "height": 42.0
           },
           "layout": "hbox"
@@ -254,7 +251,7 @@
         "y": 350.0
       },
       "size": {
-        "width": 115.8125,
+        "width": 117.015625,
         "height": 52.0
       },
       "layout": "vbox"
@@ -268,24 +265,23 @@
           "id": "task3_header",
           "children": [
             {
-              "commandId": "simulate-command",
               "id": "task3_icon",
               "children": [
                 {
                   "id": "task3_ticon",
                   "type": "label:icon",
                   "position": {
-                    "x": 7.65625,
-                    "y": 4.796875
+                    "x": 7.4921875,
+                    "y": 5.0
                   },
                   "size": {
-                    "width": 16.6875,
-                    "height": 22.40625
+                    "width": 17.015625,
+                    "height": 22.0
                   },
                   "text": "M",
                   "alignment": {
                     "x": 8.34375,
-                    "y": 18.40625
+                    "y": 18.0
                   }
                 }
               ],
@@ -309,16 +305,16 @@
               "type": "label:heading",
               "position": {
                 "x": 38.0,
-                "y": 9.796875
+                "y": 10.0
               },
               "size": {
                 "width": 76.953125,
-                "height": 22.40625
+                "height": 22.0
               },
               "text": "PreHeat",
               "alignment": {
                 "x": 37.8125,
-                "y": 18.40625
+                "y": 18.0
               }
             }
           ],
@@ -354,24 +350,23 @@
           "id": "task4_header",
           "children": [
             {
-              "commandId": "simulate-command",
               "id": "task4_icon",
               "children": [
                 {
                   "id": "task4_ticon",
                   "type": "label:icon",
                   "position": {
-                    "x": 7.65625,
-                    "y": 4.796875
+                    "x": 7.4921875,
+                    "y": 5.0
                   },
                   "size": {
-                    "width": 16.6875,
-                    "height": 22.40625
+                    "width": 17.015625,
+                    "height": 22.0
                   },
                   "text": "M",
                   "alignment": {
                     "x": 8.34375,
-                    "y": 18.40625
+                    "y": 18.0
                   }
                 }
               ],
@@ -395,16 +390,16 @@
               "type": "label:heading",
               "position": {
                 "x": 38.0,
-                "y": 9.796875
+                "y": 10.0
               },
               "size": {
-                "width": 50.15625,
-                "height": 22.40625
+                "width": 50.359375,
+                "height": 22.0
               },
               "text": "Brew",
               "alignment": {
                 "x": 24.453125,
-                "y": 18.40625
+                "y": 18.0
               }
             }
           ],
@@ -414,7 +409,7 @@
             "y": 5.0
           },
           "size": {
-            "width": 93.15625,
+            "width": 93.359375,
             "height": 42.0
           },
           "layout": "hbox"
@@ -426,7 +421,7 @@
         "y": 260.0
       },
       "size": {
-        "width": 103.15625,
+        "width": 103.359375,
         "height": 52.0
       },
       "layout": "vbox"
@@ -440,24 +435,23 @@
           "id": "task6_header",
           "children": [
             {
-              "commandId": "simulate-command",
               "id": "task6_icon",
               "children": [
                 {
                   "id": "task6_ticon",
                   "type": "label:icon",
                   "position": {
-                    "x": 7.65625,
-                    "y": 4.796875
+                    "x": 7.4921875,
+                    "y": 5.0
                   },
                   "size": {
-                    "width": 16.6875,
-                    "height": 22.40625
+                    "width": 17.015625,
+                    "height": 22.0
                   },
                   "text": "M",
                   "alignment": {
                     "x": 8.34375,
-                    "y": 18.40625
+                    "y": 18.0
                   }
                 }
               ],
@@ -481,16 +475,16 @@
               "type": "label:heading",
               "position": {
                 "x": 38.0,
-                "y": 9.796875
+                "y": 10.0
               },
               "size": {
-                "width": 73.9375,
-                "height": 22.40625
+                "width": 74.125,
+                "height": 22.0
               },
               "text": "KeepTp",
               "alignment": {
                 "x": 36.671875,
-                "y": 18.40625
+                "y": 18.0
               }
             }
           ],
@@ -500,7 +494,7 @@
             "y": 5.0
           },
           "size": {
-            "width": 116.9375,
+            "width": 117.125,
             "height": 42.0
           },
           "layout": "hbox"
@@ -512,7 +506,7 @@
         "y": 300.0
       },
       "size": {
-        "width": 126.9375,
+        "width": 127.125,
         "height": 52.0
       },
       "layout": "vbox"
@@ -526,7 +520,6 @@
           "id": "task8_header",
           "children": [
             {
-              "commandId": "simulate-command",
               "id": "task8_icon",
               "children": [
                 {
@@ -534,16 +527,16 @@
                   "type": "label:icon",
                   "position": {
                     "x": 7.9921875,
-                    "y": 4.796875
+                    "y": 5.0
                   },
                   "size": {
                     "width": 16.015625,
-                    "height": 22.40625
+                    "height": 22.0
                   },
                   "text": "A",
                   "alignment": {
-                    "x": 8.28125,
-                    "y": 18.40625
+                    "x": 7.671875,
+                    "y": 18.0
                   }
                 }
               ],
@@ -567,16 +560,16 @@
               "type": "label:heading",
               "position": {
                 "x": 38.0,
-                "y": 9.796875
+                "y": 10.0
               },
               "size": {
-                "width": 64.671875,
-                "height": 22.40625
+                "width": 65.671875,
+                "height": 22.0
               },
               "text": "ChkWt",
               "alignment": {
-                "x": 31.671875,
-                "y": 18.40625
+                "x": 32.671875,
+                "y": 18.0
               }
             }
           ],
@@ -586,7 +579,7 @@
             "y": 5.0
           },
           "size": {
-            "width": 107.671875,
+            "width": 108.671875,
             "height": 42.0
           },
           "layout": "hbox"
@@ -598,7 +591,7 @@
         "y": 160.0
       },
       "size": {
-        "width": 117.671875,
+        "width": 118.671875,
         "height": 52.0
       },
       "layout": "vbox"
@@ -612,7 +605,6 @@
           "id": "task9_header",
           "children": [
             {
-              "commandId": "simulate-command",
               "id": "task9_icon",
               "children": [
                 {
@@ -620,16 +612,16 @@
                   "type": "label:icon",
                   "position": {
                     "x": 7.9921875,
-                    "y": 4.796875
+                    "y": 5.0
                   },
                   "size": {
                     "width": 16.015625,
-                    "height": 22.40625
+                    "height": 22.0
                   },
                   "text": "A",
                   "alignment": {
-                    "x": 8.28125,
-                    "y": 18.40625
+                    "x": 7.671875,
+                    "y": 18.0
                   }
                 }
               ],
@@ -653,16 +645,16 @@
               "type": "label:heading",
               "position": {
                 "x": 38.0,
-                "y": 9.796875
+                "y": 10.0
               },
               "size": {
-                "width": 57.109375,
-                "height": 22.40625
+                "width": 58.109375,
+                "height": 22.0
               },
               "text": "WtOK",
               "alignment": {
-                "x": 28.578125,
-                "y": 18.40625
+                "x": 28.78125,
+                "y": 18.0
               }
             }
           ],
@@ -672,7 +664,7 @@
             "y": 5.0
           },
           "size": {
-            "width": 100.109375,
+            "width": 101.109375,
             "height": 42.0
           },
           "layout": "hbox"
@@ -684,7 +676,7 @@
         "y": 190.0
       },
       "size": {
-        "width": 110.109375,
+        "width": 111.109375,
         "height": 52.0
       },
       "layout": "vbox"

--- a/packages/theia-integration/src/browser/diagram/glsp-diagram-client.ts
+++ b/packages/theia-integration/src/browser/diagram/glsp-diagram-client.ts
@@ -26,10 +26,10 @@ import { GLSPClientContribution } from "../glsp-client-contribution";
 @injectable()
 export class GLSPDiagramClient {
 
-    actionMessageReceivers: ActionMessageReceiver[] = [];
+    protected actionMessageReceivers: ActionMessageReceiver[] = [];
 
-    @inject(ApplicationShell) readonly shell: ApplicationShell;
-    @inject(CommandRegistry) readonly commandsRegistry: CommandRegistry;
+    @inject(ApplicationShell) protected readonly shell: ApplicationShell;
+    @inject(CommandRegistry) protected readonly commandsRegistry: CommandRegistry;
 
     constructor(readonly glspClientContribution: GLSPClientContribution,
         readonly editorManager: EditorManager) {
@@ -43,7 +43,7 @@ export class GLSPDiagramClient {
             .then(client => client.sendActionMessage(message));
     }
 
-    onMessageReceived(message: ActionMessage) {
+    protected onMessageReceived(message: ActionMessage) {
         this.actionMessageReceivers.forEach(client => client.onMessageReceived(message));
     }
 
@@ -51,7 +51,7 @@ export class GLSPDiagramClient {
         return this.glspClientContribution.glspClient;
     }
 
-    didClose(clientId: string) {
+    didClose(_clientId: string) {
         // this.glspClient.then(gc => gc.stop())
     }
 

--- a/packages/theia-integration/src/browser/diagram/glsp-diagram-manager.ts
+++ b/packages/theia-integration/src/browser/diagram/glsp-diagram-manager.ts
@@ -99,7 +99,7 @@ export abstract class GLSPDiagramManager extends DiagramManager {
         return this.diagramConfigurationRegistry.get(options.diagramType);
     }
 
-    canHandle(uri: URI, options?: WidgetOpenerOptions | undefined): number {
+    canHandle(uri: URI, _options?: WidgetOpenerOptions | undefined): number {
         for (const extension of this.fileExtensions) {
             if (uri.path.toString().endsWith(extension)) {
                 return 1001;

--- a/packages/theia-integration/src/browser/diagram/glsp-diagram-widget.ts
+++ b/packages/theia-integration/src/browser/diagram/glsp-diagram-widget.ts
@@ -42,8 +42,8 @@ import { DirtyStateNotifier, GLSPTheiaDiagramServer } from "./glsp-theia-diagram
 export class GLSPDiagramWidget extends DiagramWidget implements SaveableSource {
 
     protected copyPasteHandler?: ICopyPasteHandler;
-    saveable = new SaveableGLSPModelSource(this.actionDispatcher, this.diContainer.get<ModelSource>(TYPES.ModelSource));
-    options: DiagramWidgetOptions & GLSPWidgetOptions;
+    public saveable = new SaveableGLSPModelSource(this.actionDispatcher, this.diContainer.get<ModelSource>(TYPES.ModelSource));
+    protected options: DiagramWidgetOptions & GLSPWidgetOptions;
 
     constructor(options: DiagramWidgetOptions & GLSPWidgetOpenerOptions, readonly widgetId: string, readonly diContainer: Container,
         readonly editorPreferences: EditorPreferences, readonly connector?: TheiaSprottyConnector) {

--- a/packages/theia-integration/src/browser/diagram/glsp-theia-diagram-server.ts
+++ b/packages/theia-integration/src/browser/diagram/glsp-theia-diagram-server.ts
@@ -18,18 +18,20 @@ import {
     ActionHandlerRegistry,
     ComputedBoundsAction,
     isServerMessageAction,
+    isSetEditModeAction,
     registerDefaultGLSPServerActions,
     ServerMessageAction,
     SetEditModeAction,
-    SourceUriAware,
-    isSetEditModeAction
+    SourceUriAware
 } from "@eclipse-glsp/client";
 import { Emitter, Event } from "@theia/core/lib/common";
 import { injectable } from "inversify";
 import { TheiaDiagramServer } from "sprotty-theia";
 
 import { GLSPTheiaSprottyConnector } from "./glsp-theia-sprotty-connector";
+
 const receivedFromServerProperty = '__receivedFromServer';
+
 @injectable()
 export class GLSPTheiaDiagramServer extends TheiaDiagramServer implements DirtyStateNotifier, SourceUriAware {
 
@@ -72,7 +74,7 @@ export class GLSPTheiaDiagramServer extends TheiaDiagramServer implements DirtyS
         return super.handleLocally(action);
     }
 
-    protected handleComputedBounds(action: ComputedBoundsAction): boolean {
+    protected handleComputedBounds(_action: ComputedBoundsAction): boolean {
         return true;
     }
 
@@ -88,8 +90,7 @@ export class GLSPTheiaDiagramServer extends TheiaDiagramServer implements DirtyS
 
 export class SetDirtyStateAction implements Action {
     static readonly KIND = 'setDirtyState';
-    readonly kind = SetDirtyStateAction.KIND;
-    constructor(public isDirty: boolean) { }
+    constructor(public isDirty: boolean, public readonly kind = SetDirtyStateAction.KIND) { }
 }
 
 export function isSetDirtyStateAction(action: Action): action is SetDirtyStateAction {

--- a/packages/theia-integration/src/browser/diagram/glsp-theia-marker-manager.ts
+++ b/packages/theia-integration/src/browser/diagram/glsp-theia-marker-manager.ts
@@ -64,7 +64,7 @@ export class TheiaMarkerManager extends ExternalMarkerManager {
     }
 
     @postConstruct()
-    initialize() {
+    protected initialize() {
         if (this.problemManager) {
             this.problemManager.onDidChangeMarkers(uri => this.refreshMarker(uri));
         }

--- a/packages/theia-integration/src/browser/diagram/glsp-theia-sprotty-connector.ts
+++ b/packages/theia-integration/src/browser/diagram/glsp-theia-sprotty-connector.ts
@@ -86,12 +86,12 @@ export class GLSPTheiaSprottyConnector implements TheiaSprottyConnector, GLSPThe
         }
     }
 
-    clearWidgetStatus(widgetId: string) {
+    protected clearWidgetStatus(widgetId: string) {
         // any status but FATAL, ERROR, WARNING or INFO will lead to a clear of the status
         this.showWidgetStatus(widgetId, { kind: ServerStatusAction.KIND, message: '', severity: 'CLEAR' });
     }
 
-    showWidgetStatus(widgetId: string, status: ServerStatusAction): void {
+    protected showWidgetStatus(widgetId: string, status: ServerStatusAction): void {
         // remove any pending timeout
         const pendingTimeout = this.widgetStatusTimeouts.get(widgetId);
         if (pendingTimeout) {
@@ -123,17 +123,17 @@ export class GLSPTheiaSprottyConnector implements TheiaSprottyConnector, GLSPThe
         }
     }
 
-    clearServerMessages(widgetId: string) {
+    protected clearServerMessages(widgetId: string) {
         const widgetMessages = Array.from(this.widgetMessages.get(widgetId) || []);
         widgetMessages.forEach(messageId => this.clearServerMessage(widgetId, messageId));
     }
 
-    clearServerMessage(widgetId: string, messageId: string) {
+    protected clearServerMessage(widgetId: string, messageId: string) {
         remove(this.widgetMessages.get(widgetId) || [], messageId);
         this.notificationManager.clear(messageId);
     }
 
-    showServerMessage(widgetId: string, action: ServerMessageAction) {
+    protected showServerMessage(widgetId: string, action: ServerMessageAction) {
         const widget = this.widgetManager.getWidgets(this.diagramManager.id).find(w => w.id === widgetId);
         const uri = widget instanceof DiagramWidget ? widget.uri.toString() : '';
 
@@ -167,7 +167,7 @@ export class GLSPTheiaSprottyConnector implements TheiaSprottyConnector, GLSPThe
         }
     }
 
-    addServerMessage(widgetId: string, messageId: string) {
+    protected addServerMessage(widgetId: string, messageId: string) {
         const widgetMessages = this.widgetMessages.get(widgetId) || [];
         widgetMessages.push(messageId);
         this.widgetMessages.set(widgetId, widgetMessages);
@@ -181,7 +181,7 @@ export class GLSPTheiaSprottyConnector implements TheiaSprottyConnector, GLSPThe
         }
     }
 
-    toMessageType(severity: string) {
+    protected toMessageType(severity: string) {
         switch (severity) {
             case 'ERROR':
                 return MessageType.Error;
@@ -193,7 +193,7 @@ export class GLSPTheiaSprottyConnector implements TheiaSprottyConnector, GLSPThe
         return MessageType.Log;
     }
 
-    isClear(severity: string) {
+    protected isClear(severity: string) {
         return severity === 'NONE';
     }
 

--- a/packages/theia-integration/src/browser/glsp-client-contribution.ts
+++ b/packages/theia-integration/src/browser/glsp-client-contribution.ts
@@ -45,6 +45,7 @@ export interface GLSPClientContribution extends GLSPContribution {
     activate(app: FrontendApplication): Disposable;
     deactivate(app: FrontendApplication): void;
 }
+
 @injectable()
 export abstract class BaseGLSPClientContribution implements GLSPClientContribution {
 

--- a/packages/theia-integration/src/browser/glsp-frontend-contribution.ts
+++ b/packages/theia-integration/src/browser/glsp-frontend-contribution.ts
@@ -24,10 +24,8 @@ export class GLSPFrontendContribution implements FrontendApplicationContribution
     @inject(FrontendApplication)
     protected readonly app: FrontendApplication;
 
-    constructor(
-        @inject(ContributionProvider) @named(GLSPClientContribution)
-        protected readonly contributions: ContributionProvider<GLSPClientContribution>
-    ) { }
+    @inject(ContributionProvider) @named(GLSPClientContribution)
+    protected readonly contributions: ContributionProvider<GLSPClientContribution>;
 
     onStart(app: FrontendApplication): void {
         for (const contribution of this.contributions.getContributions()) {

--- a/packages/theia-integration/src/browser/theia-navigate-to-marker-contribution.ts
+++ b/packages/theia-integration/src/browser/theia-navigate-to-marker-contribution.ts
@@ -36,6 +36,7 @@ export namespace NavigateToMarkerCommand {
 @injectable()
 export class NavigateToMarkerCommandContribution implements CommandContribution {
     @inject(ApplicationShell) protected readonly shell: ApplicationShell;
+
     registerCommands(commands: CommandRegistry): void {
         commands.registerCommand({ id: NavigateToMarkerCommand.NEXT_MARKER, label: 'Go to Next Marker', category: 'Diagram' },
             new GLSPCommandHandler(this.shell, {
@@ -55,6 +56,7 @@ export class NavigateToMarkerCommandContribution implements CommandContribution 
 @injectable()
 export class NavigateToMarkerMenuContribution implements MenuContribution {
     static readonly NAVIGATION = GLSPContextMenu.MENU_PATH.concat('navigate');
+
     registerMenus(menus: MenuModelRegistry): void {
         menus.registerSubmenu(NavigateToMarkerMenuContribution.NAVIGATION, "Go to");
         menus.registerMenuAction(NavigateToMarkerMenuContribution.NAVIGATION.concat('m'), { commandId: NavigateToMarkerCommand.NEXT_MARKER, label: 'Next Marker' });
@@ -65,6 +67,7 @@ export class NavigateToMarkerMenuContribution implements MenuContribution {
 @injectable()
 export class NavigateToMarkerKeybindingContribution implements KeybindingContribution {
     @inject(DiagramKeybindingContext) protected readonly diagramKeybindingContext: DiagramKeybindingContext;
+
     registerKeybindings(keybindings: KeybindingRegistry): void {
         keybindings.registerKeybinding({
             command: NavigateToMarkerCommand.NEXT_MARKER,

--- a/packages/theia-integration/src/node/glsp-backend-contribution.ts
+++ b/packages/theia-integration/src/node/glsp-backend-contribution.ts
@@ -31,7 +31,7 @@ export class GLSPBackendContribution implements MessagingService.Contribution, G
     protected nextId: number = 1;
     protected readonly sessions = new Map<string, any>();
 
-    async create(contributionId: string, startParameters: any): Promise<string> {
+    async create(_contributionId: string, startParameters: any): Promise<string> {
         const id = this.nextId;
         this.nextId++;
         const sessionId = String(id);


### PR DESCRIPTION
- Use property injection over constructor injection
- Avoid readonly properties in classes that should be customizable
- Remove 'simulate-command' from Workflow example

Part of https://github.com/eclipse-glsp/glsp/issues/66
Part of https://github.com/eclipse-glsp/glsp/issues/72
Part of https://github.com/eclipse-glsp/glsp/issues/131

Signed-off-by: Martin Fleck <mfleck@eclipsesource.com>