### PR TITLE
#35 Extend GLSPServerContribution to support embedded server launch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ yarn-error.log
 examples/browser-app/**
 !examples/browser-app/package.json
 
+examples/**/server/**
+!examples/**/server/download.ts
+

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,91 @@
+{
+  // Use IntelliSense to learn about possible Node.js debug attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Launch Workflow Browser Backend",
+      "program": "${workspaceRoot}/examples/browser-app/src-gen/backend/main.js",
+      "args": [
+        "--hostname=localhost",
+        "--WF_GLSP=5007",
+        "--port=3000",
+        "--no-cluster",
+        "--root-dir=${workspaceRoot}/examples/workspace",
+        "--app-project-path=${workspaceRoot}/examples/browser-app"
+      ],
+      "env": {
+        "NODE_ENV": "development"
+      },
+      "sourceMaps": true,
+      "outFiles": [
+        "${workspaceRoot}/node_modules/@theia/*/lib/**/*.js",
+        "${workspaceRoot}/examples/browser-app/lib/**/*.js",
+        "${workspaceRoot}/examples/browser-app/src-gen/**/*.js",
+        "${workspaceRoot}/packages/*/lib/**/*.js",
+        "${workspaceRoot}/examples/*/lib/**/*.js"
+      ],
+      "smartStep": true,
+      "internalConsoleOptions": "openOnSessionStart",
+      "outputCapture": "std",
+      "presentation": {
+        "group": "Browser launch configurations",
+        "order": 1
+      }
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Launch Workflow Browser Backend (DEBUG)",
+      "program": "${workspaceRoot}/examples/browser-app/src-gen/backend/main.js",
+      "args": [
+        "--hostname=localhost",
+        "--WF_GLSP=5007",
+        "--port=3000",
+        "--no-cluster",
+        "--root-dir=${workspaceRoot}/examples/workspace",
+        "--app-project-path=${workspaceRoot}/examples/browser-app",
+        "--debug",
+        "--loglevel=debug"
+      ],
+      "env": {
+        "NODE_ENV": "development"
+      },
+      "sourceMaps": true,
+      "outFiles": [
+        "${workspaceRoot}/node_modules/@theia/*/lib/**/*.js",
+        "${workspaceRoot}/examples/browser-app/lib/**/*.js",
+        "${workspaceRoot}/examples/browser-app/src-gen/**/*.js",
+        "${workspaceRoot}/packages/*/lib/**/*.js",
+        "${workspaceRoot}/examples/*/lib/**/*.js"
+      ],
+      "smartStep": true,
+      "internalConsoleOptions": "openOnSessionStart",
+      "outputCapture": "std",
+      "presentation": {
+        "group": "Browser launch configurations",
+        "order": 1
+      }
+    },
+    {
+      "type": "chrome",
+      "request": "launch",
+      "name": "Launch Workflow Browser Frontend",
+      "url": "http://localhost:3000",
+      "webRoot": "${workspaceFolder}",
+      "sourceMapPathOverrides": {
+        "./src/*": "${workspaceFolder}/src/*"
+      },
+      "presentation": {
+        "group": "Browser launch configurations",
+        "order": 2
+      },
+      "runtimeArgs": [
+        "--incognito"
+      ]
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -34,7 +34,29 @@
       "label": "[Theia] Start Workflow Theia Backend Example",
       "type": "shell",
       "group": "test",
+      "command": "cd examples/browser-app && yarn start",
+      "presentation": {
+        "reveal": "always",
+        "panel": "new"
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "[Theia] Start Workflow Theia Backend Example (DEBUG)",
+      "type": "shell",
+      "group": "test",
       "command": "cd examples/browser-app && yarn start:debug",
+      "presentation": {
+        "reveal": "always",
+        "panel": "new"
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "[Theia] Download latest Workflow Example Java server",
+      "type": "shell",
+      "group": "test",
+      "command": "yarn download:exampleServer",
       "presentation": {
         "reveal": "always",
         "panel": "new"

--- a/examples/browser-app/package.json
+++ b/examples/browser-app/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "prepare": "theia build --mode development",
     "start": "theia start --WF_GLSP=5007 --root-dir=../workspace",
-    "start:debug": "theia start --WF_GLSP=5007  --root-dir=../workspace --loglevel=debug",
+    "start:debug": "theia start --WF_GLSP=5007  --root-dir=../workspace --loglevel=debug --debug",
     "watch": "theia build --watch --mode development"
   },
   "theia": {

--- a/examples/workflow-theia/package.json
+++ b/examples/workflow-theia/package.json
@@ -8,7 +8,8 @@
   "license": "(EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0)",
   "files": [
     "lib",
-    "src"
+    "src",
+    "server"
   ],
   "author": {
     "name": "EclipseSource"
@@ -20,7 +21,9 @@
   "devDependencies": {
     "rimraf": "^2.6.1",
     "tslint": "^5.5.0",
-    "typescript": "^3.9.2"
+    "typescript": "^3.9.2",
+    "mvn-artifact-download": "5.1.0",
+    "ts-node": "9.0.0"
   },
   "scripts": {
     "prepare": "yarn run clean && yarn run build",

--- a/examples/workflow-theia/server/download.ts
+++ b/examples/workflow-theia/server/download.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2019-2020 EclipseSource and others.
+ * Copyright (c) 2020 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -13,6 +13,16 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-export * from './glsp-server-contribution';
-export * from './java-socket-glsp-server';
-export * from './glsp-backend-contribution';
+import download from "mvn-artifact-download";
+import { join, resolve } from "path";
+
+const downloadDir = resolve(join(__dirname));
+const mavenRepository = "https://oss.sonatype.org/content/repositories/snapshots/";
+const groupId = "org.eclipse.glsp.example";
+const artifactId = "org.eclipse.glsp.example.workflow";
+const version = "0.8.0";
+const classifier = "glsp";
+
+console.log("Download latest version of the Workflow Example Java Server from the maven repository.");
+download({ groupId, artifactId, version, classifier, isSnapShot: true }, downloadDir, mavenRepository)
+    .then(() => console.log("Download completed."));

--- a/examples/workflow-theia/src/node/workflow-backend-module.ts
+++ b/examples/workflow-theia/src/node/workflow-backend-module.ts
@@ -19,5 +19,6 @@ import { ContainerModule } from "inversify";
 import { WorkflowGLServerContribution } from "./workflow-glsp-server-contribution";
 
 export default new ContainerModule(bind => {
-    bind(GLSPServerContribution).to(WorkflowGLServerContribution).inSingletonScope();
+    bind(WorkflowGLServerContribution).toSelf().inSingletonScope();
+    bind(GLSPServerContribution).toService(WorkflowGLServerContribution);
 });

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "publish": "yarn && yarn publish:latest",
     "publish:latest": "lerna publish",
     "publish:next": "lerna publish --exact --canary=next --npm-tag=next --yes",
-    "update:next": "yarn upgrade -p \"@eclipse-glsp/.*|sprotty-theia|sprotty\" --next "
+    "update:next": "yarn upgrade -p \"@eclipse-glsp/.*|sprotty-theia|sprotty\" --next ",
+    "download:exampleServer": "ts-node examples/workflow-theia/server/download.ts"
   },
   "devDependencies": {
     "@wdio/cli": "^6.0.14",

--- a/packages/theia-integration/src/node/glsp-server-contribution.ts
+++ b/packages/theia-integration/src/node/glsp-server-contribution.ts
@@ -38,32 +38,29 @@ export interface GLSPServerContribution extends GLSPContribution {
      * @returns A 'Promise' that resolves after the server has been successfully launched and is ready to establish a client connection.
      */
     launch?(): Promise<void>
+
     /**
      * The {@link GLSPServerLaunchOptions} for this contribution.
      */
     launchOptions: GLSPServerLaunchOptions
-
-    /***
-     * Queries the contribution to determine wether a server instance is currently running.
-     * @returns `true` if a server instance is currently running.
-     */
-    isServerRunning(): boolean
 }
 export interface GLSPServerLaunchOptions {
-    /** Declares if the server can handle multiple clients.
+    /**
+     * Declares if the server can handle multiple clients.
      * A `multiClient` server only has to be started once whereas in a `singleClient` scenario a new server needs to be launched for each client.
      */
     multiClient: boolean
     /** Declares wether the  server should be launched on application start or on demand (e.g. on widget open). */
     launchOnDemand: boolean
-    /** Declares that the server contribution does not have to consider server launching. This will be done externally.
-     *  Mostly used for debug purposes.
+    /**
+     * Declares that the server contribution does not have to consider server launching. This will be done externally.
+     * Mostly used for debug purposes.
      */
     launchedExternally: boolean
 }
 
 export namespace GLSPServerLaunchOptions {
-    /** Default values for {@link GLSPServerLaunchOptions }**/
+    /** Default values for {@link GLSPServerLaunchOptions } **/
     export function createDefaultOptions(): GLSPServerLaunchOptions {
         return <GLSPServerLaunchOptions>{
             multiClient: true,
@@ -96,6 +93,7 @@ export namespace GLSPServerLaunchOptions {
         const args = process.argv.filter(a => a.startsWith(debugArgument));
         return args.length > 0;
     }
+
     /**
      * Utility function that processes the contribution launch options to determine wether the server should be launched on
      * application start.
@@ -118,7 +116,6 @@ export abstract class BaseGLSPServerContribution implements GLSPServerContributi
     @inject(ProcessManager) protected readonly processManager: ProcessManager;
     abstract readonly id: string;
     abstract readonly name: string;
-    protected running = false;
     launchOptions: GLSPServerLaunchOptions = GLSPServerLaunchOptions.createDefaultOptions();
 
     abstract connect(clientConnection: IConnection): void;
@@ -137,10 +134,6 @@ export abstract class BaseGLSPServerContribution implements GLSPServerContributi
         if (WebSocketChannelConnection.is(clientConnection)) {
             serverConnection.onClose(() => clientConnection.channel.tryClose());
         }
-    }
-
-    isServerRunning(): boolean {
-        return this.running;
     }
 
     protected spawnProcessAsync(command: string, args?: string[], options?: cp.SpawnOptions) {

--- a/packages/theia-integration/src/node/java-socket-glsp-server.ts
+++ b/packages/theia-integration/src/node/java-socket-glsp-server.ts
@@ -78,21 +78,19 @@ export abstract class JavaSocketServerContribution extends BaseGLSPServerContrib
         this.connectToSocketServer(clientConnection);
     }
     async launch(): Promise<void> {
-        if (!this.launchOptions.multiClient || !this.isServerRunning()) {
-            if (!fs.existsSync(this.launchOptions.jarPath)) {
-                throw Error(`Could not launch GLSP server. The given jar path is not valid: ${this.launchOptions.jarPath}`);
-            }
-            if (isNaN(this.launchOptions.serverPort)) {
-                throw new Error(`Could not launch GLSP Server. The given server port is not a number: ${this.launchOptions.serverPort}`);
-            }
-            let args = ["-jar", this.launchOptions.jarPath, "--port", `${this.launchOptions.serverPort}`];
-            if (this.launchOptions.additionalArgs) {
-                args = [...args, ...this.launchOptions.additionalArgs];
-            }
-
-            await this.spawnProcessAsync("java", args, undefined);
-            return this.onReady;
+        if (!fs.existsSync(this.launchOptions.jarPath)) {
+            throw Error(`Could not launch GLSP server. The given jar path is not valid: ${this.launchOptions.jarPath}`);
         }
+        if (isNaN(this.launchOptions.serverPort)) {
+            throw new Error(`Could not launch GLSP Server. The given server port is not a number: ${this.launchOptions.serverPort}`);
+        }
+        let args = ["-jar", this.launchOptions.jarPath, "--port", `${this.launchOptions.serverPort}`];
+        if (this.launchOptions.additionalArgs) {
+            args = [...args, ...this.launchOptions.additionalArgs];
+        }
+
+        await this.spawnProcessAsync("java", args, undefined);
+        return this.onReady;
     }
 
 

--- a/packages/theia-integration/src/node/java-socket-glsp-server.ts
+++ b/packages/theia-integration/src/node/java-socket-glsp-server.ts
@@ -1,0 +1,124 @@
+/********************************************************************************
+ * Copyright (c) 2020 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+import * as fs from "fs";
+import { injectable, postConstruct } from "inversify";
+import * as net from "net";
+import { createSocketConnection, IConnection } from "vscode-ws-jsonrpc/lib/server";
+
+import { BaseGLSPServerContribution, GLSPServerLaunchOptions } from "./glsp-server-contribution";
+
+export const START_UP_COMPLETE_MSG = "[GLSP-Server]:Startup completed";
+export interface JavaSocketServerLaunchOptions extends GLSPServerLaunchOptions {
+    /** Path to the location of the jar file that should be launched as process */
+    jarPath: string,
+    /** Port on which the server should listen for new client connections */
+    serverPort: number,
+    /** Additional arguments that should be passed when starting the server process. */
+    additionalArgs?: string[]
+}
+
+export namespace JavaSocketServerLaunchOptions {
+    /** Default values for {@link JavaGLSPServerLaunchOptions }**/
+    export function createDefaultOptions(): JavaSocketServerLaunchOptions {
+        return <JavaSocketServerLaunchOptions>{
+            ...GLSPServerLaunchOptions.createDefaultOptions(),
+            jarPath: "",
+            serverPort: NaN
+        };
+    }
+
+    /**
+    * Utility function to partially set the launch options. Default values (from 'defaultOptions') are used for
+    * options that are not specified.
+    * @param options (partial) launch options that should be extended with default values (if necessary)
+    */
+    export function configure(options?: Partial<JavaSocketServerLaunchOptions>): JavaSocketServerLaunchOptions {
+        return options ?
+            <JavaSocketServerLaunchOptions>{
+                ...createDefaultOptions(),
+                ...options
+            } : createDefaultOptions();
+    }
+}
+
+/**
+ *  A reusable base implementation for {@link GLSPServerContribution}s that are using a socket connection to communicate
+ *  with a java-based GLSP server.
+ **/
+@injectable()
+export abstract class JavaSocketServerContribution extends BaseGLSPServerContribution {
+
+    protected resolveReady: (value?: void | PromiseLike<void> | undefined) => void;
+    onReady: Promise<void> = new Promise(resolve => this.resolveReady = resolve);
+    launchOptions: JavaSocketServerLaunchOptions;
+
+    @postConstruct()
+    protected initialize() {
+        if (this.createLaunchOptions) {
+            this.launchOptions = JavaSocketServerLaunchOptions.configure(this.createLaunchOptions());
+        }
+    }
+
+    abstract createLaunchOptions(): Partial<JavaSocketServerLaunchOptions>;
+
+    connect(clientConnection: IConnection): void {
+        this.connectToSocketServer(clientConnection);
+    }
+    async launch(): Promise<void> {
+        if (!this.launchOptions.multiClient || !this.isServerRunning()) {
+            if (!fs.existsSync(this.launchOptions.jarPath)) {
+                throw Error(`Could not launch GLSP server. The given jar path is not valid: ${this.launchOptions.jarPath}`);
+            }
+            if (isNaN(this.launchOptions.serverPort)) {
+                throw new Error(`Could not launch GLSP Server. The given server port is not a number: ${this.launchOptions.serverPort}`);
+            }
+            let args = ["-jar", this.launchOptions.jarPath, "--port", `${this.launchOptions.serverPort}`];
+            if (this.launchOptions.additionalArgs) {
+                args = [...args, ...this.launchOptions.additionalArgs];
+            }
+
+            await this.spawnProcessAsync("java", args, undefined);
+            return this.onReady;
+        }
+    }
+
+
+    protected processLogInfo(data: string | Buffer): void {
+        if (data) {
+            const message = data.toString();
+            if (message.startsWith(START_UP_COMPLETE_MSG)) {
+                this.resolveReady();
+            }
+        }
+    }
+
+    protected processLogError(data: string | Buffer): void {
+        // Override console logging of errors. To avoid a polluted client console.
+    }
+
+    protected connectToSocketServer(clientConnection: IConnection) {
+        if (isNaN(this.launchOptions.serverPort)) {
+            throw new Error(`Could not connect to to GLSP Server. The given server port is not a number: ${this.launchOptions.serverPort}`);
+        }
+        const socket = new net.Socket();
+        const serverConnection = createSocketConnection(socket, socket, () => {
+            socket.destroy();
+        });
+        this.forward(clientConnection, serverConnection);
+        socket.connect(this.launchOptions.serverPort);
+    }
+}
+

--- a/yarn.lock
+++ b/yarn.lock
@@ -2313,6 +2313,11 @@ are-we-there-yet@~1.1.2:
     delegates "^1.0.0"
     readable-stream "^2.0.6"
 
+arg@^4.1.0:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
+  integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
+
 argparse@^1.0.7:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
@@ -8287,6 +8292,11 @@ make-dir@^3.0.0, make-dir@^3.0.2:
   dependencies:
     semver "^6.0.0"
 
+make-error@^1.1.1:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
+  integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
+
 map-age-cleaner@^0.1.1:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz#7d583a7306434c055fe474b0f45078e6e1b4b92a"
@@ -8868,6 +8878,35 @@ mv@^2.1.1:
     mkdirp "~0.5.1"
     ncp "~2.0.0"
     rimraf "~2.4.0"
+
+mvn-artifact-download@5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/mvn-artifact-download/-/mvn-artifact-download-5.1.0.tgz#332c89992196e307cd00768e0fcb29cdb30a814a"
+  integrity sha512-8Cdikbcotum2TZDI6bn3DtYYKIyjFKTDbM9CCrSLWVkAa8fd5s5Di1ti30I0J3vFYx+a2ZCcnaqNSgfvxZFMxQ==
+  dependencies:
+    mvn-artifact-filename "^5.1.0"
+    mvn-artifact-name-parser "^5.0.1"
+    mvn-artifact-url "^5.1.0"
+    node-fetch "^2.6.0"
+
+mvn-artifact-filename@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/mvn-artifact-filename/-/mvn-artifact-filename-5.1.0.tgz#722e548b2a517a2af2ff6982e2952cde91346f55"
+  integrity sha512-HgChSCBgeTQhWw4ELf0SDIyE8eok2A328aPq6BkPbJc5Pv9HNoREwhw887LnNXpNKty+xaE84DR3IguW+ct5Zw==
+
+mvn-artifact-name-parser@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/mvn-artifact-name-parser/-/mvn-artifact-name-parser-5.0.1.tgz#e2467a4809a1cc4285e80b4344ff06daef3540a0"
+  integrity sha512-CyWPiWAe3Ubnf9joDLg9cIYoGu/QZXg926qXtohXdx/B/ZHTG/hXwtKt/vmezRw68irmUxAYRYCQCuolmgNLAA==
+
+mvn-artifact-url@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/mvn-artifact-url/-/mvn-artifact-url-5.1.0.tgz#5ae73b3e1da70ee1e0b40b0fca5b90c791dabe35"
+  integrity sha512-2JazIVxtxnuA3MiheI/c2HgwJmWprH0zR02WjGNhtiRjmmWsa1aZMgqEradEJMM2EaHHmJZbMkfkH1J7fVTYbw==
+  dependencies:
+    mvn-artifact-filename "^5.1.0"
+    node-fetch "^2.6.0"
+    xml2js "^0.4.23"
 
 nan@^2.0.0, nan@^2.10.0, nan@^2.12.1, nan@^2.14.0:
   version "2.14.2"
@@ -11015,7 +11054,7 @@ safe-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
-sax@~1.2.1:
+sax@>=0.6.0, sax@~1.2.1:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
@@ -11381,7 +11420,7 @@ source-map-support@^0.4.15, source-map-support@^0.4.18:
   dependencies:
     source-map "^0.5.6"
 
-source-map-support@~0.5.12:
+source-map-support@^0.5.17, source-map-support@~0.5.12:
   version "0.5.19"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
   integrity sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==
@@ -12148,6 +12187,17 @@ ts-md5@^1.2.2:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/ts-md5/-/ts-md5-1.2.7.tgz#b76471fc2fd38f0502441f6c3b9494ed04537401"
   integrity sha512-emODogvKGWi1KO1l9c6YxLMBn6CEH3VrH5mVPIyOtxBG52BvV4jP3GWz6bOZCz61nLgBc3ffQYE4+EHfCD+V7w==
+
+ts-node@9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-9.0.0.tgz#e7699d2a110cc8c0d3b831715e417688683460b3"
+  integrity sha512-/TqB4SnererCDR/vb4S/QvSZvzQMJN8daAslg7MeaiHvD8rDZsSfXmNeNumyZZzMned72Xoq/isQljYSt8Ynfg==
+  dependencies:
+    arg "^4.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    source-map-support "^0.5.17"
+    yn "3.1.1"
 
 tslib@^1.10.0, tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0:
   version "1.14.1"
@@ -12946,6 +12996,19 @@ xdg-trashdir@^2.1.1:
     user-home "^2.0.0"
     xdg-basedir "^2.0.0"
 
+xml2js@^0.4.23:
+  version "0.4.23"
+  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.23.tgz#a0c69516752421eb2ac758ee4d4ccf58843eac66"
+  integrity sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==
+  dependencies:
+    sax ">=0.6.0"
+    xmlbuilder "~11.0.0"
+
+xmlbuilder@~11.0.0:
+  version "11.0.1"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-11.0.1.tgz#be9bae1c8a046e76b31127726347d0ad7002beb3"
+  integrity sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==
+
 xtend@^4.0.0, xtend@~4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
@@ -13259,6 +13322,11 @@ yeoman-generator@^4.8.2:
   optionalDependencies:
     grouped-queue "^1.1.0"
     yeoman-environment "^2.9.5"
+
+yn@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
+  integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
 
 zip-dir@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
Base framework:
- Refactor & document GLSPServerContribution API
-- Rename "start" method to connect.
-- Introduce optional launch method, which can be implemented in embedded server scenarios
-- Add isServerRunning() method, which checks if currently a server instance is running
-Introduce `GLSPServerLaunchOptions`.
- Introduce  a common base implementation for connecting to Java-based GLSP server via socket  ('JavaSocketGLSPServerContribution')

Example:
- Add 'download:exampleServer' script to root package.json
- Refactor WorkflowGLSPServerContribution to support embedded launching of the glsp server
- Add/rework tasks

The example can now be launched in default mode, which will be using a embedded GLSP server and in DEBUG mode which will not launch a server, and expects that the server is also running at the given port. (Previous default behavior)

Fixes eclipse-glsp/glsp/issues/35