### PR TITLE
#197 Improve dirty state handling

### DIFF
--- a/packages/theia-integration/src/browser/diagram/glsp-theia-diagram-server.ts
+++ b/packages/theia-integration/src/browser/diagram/glsp-theia-diagram-server.ts
@@ -97,11 +97,13 @@ export class GLSPTheiaDiagramServer extends TheiaDiagramServer implements DirtyS
 
 export class SetDirtyStateAction implements Action {
     static readonly KIND = 'setDirtyState';
-    constructor(public isDirty: boolean, public readonly kind = SetDirtyStateAction.KIND) { }
+    constructor(public readonly isDirty: boolean, public readonly causedBy: Action,
+        public readonly kind = SetDirtyStateAction.KIND) { }
 }
 
 export function isSetDirtyStateAction(action: Action): action is SetDirtyStateAction {
-    return SetDirtyStateAction.KIND === action.kind && ('isDirty' in action);
+    return SetDirtyStateAction.KIND === action.kind && 'isDirty' in action
+        && typeof (action['isDirty']) === 'boolean' && 'causedBy' in action;
 }
 
 export interface DirtyState {

--- a/packages/theia-integration/src/browser/diagram/glsp-theia-diagram-server.ts
+++ b/packages/theia-integration/src/browser/diagram/glsp-theia-diagram-server.ts
@@ -94,16 +94,23 @@ export class GLSPTheiaDiagramServer extends TheiaDiagramServer implements DirtyS
         return false;
     }
 }
-
 export class SetDirtyStateAction implements Action {
     static readonly KIND = 'setDirtyState';
-    constructor(public readonly isDirty: boolean, public readonly causedBy: Action,
+    constructor(public readonly isDirty: boolean, public readonly reason?: string,
         public readonly kind = SetDirtyStateAction.KIND) { }
+}
+
+export namespace DirtyStateChangeReason {
+    export const OPERATION = "operation";
+    export const UNDO = "undo";
+    export const REDO = "redo";
+    export const SAVE = "save";
+    export const EXTERNAL = "external";
 }
 
 export function isSetDirtyStateAction(action: Action): action is SetDirtyStateAction {
     return SetDirtyStateAction.KIND === action.kind && 'isDirty' in action
-        && typeof (action['isDirty']) === 'boolean' && 'causedBy' in action;
+        && typeof (action['isDirty']) === 'boolean' && 'reason' in action;
 }
 
 export interface DirtyState {


### PR DESCRIPTION
The `SetDirtyStateAction` now also declares the action/operation which caused the dirty state change. 
Part of https://github.com/eclipse-glsp/glsp/issues/197