### PR TITLE
#60#229 Stabilize yarn build and add codestyle reporting to ci build

### DIFF
--- a/examples/browser-app/package.json
+++ b/examples/browser-app/package.json
@@ -20,7 +20,8 @@
     "@theia/cli": "^1.0.0"
   },
   "scripts": {
-    "prepare": "theia build --mode development",
+    "prepare": "yarn build",
+    "build": "theia build --mode development",
     "start": "theia start --WF_GLSP=5007 --root-dir=../workspace",
     "start:debug": "theia start --WF_GLSP=5007  --root-dir=../workspace --loglevel=debug --debug",
     "watch": "theia build --watch --mode development"

--- a/examples/workflow-theia/package.json
+++ b/examples/workflow-theia/package.json
@@ -1,19 +1,32 @@
 {
   "name": "@eclipse-glsp-examples/workflow-theia",
   "version": "0.9.0",
+  "description": "Theia extension for the workflow GLSP example",
+  "license": "(EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0)",
   "keywords": [
     "theia-extension"
   ],
-  "description": "Theia extension for the workflow GLSP example",
-  "license": "(EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0)",
+  "author": {
+    "name": "Eclipse GLSP"
+  },
+  "homepage": "https://www.eclipse.org/glsp/",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/eclipse-glsp/glsp-theia-integration.git"
+  },
+  "bugs": "https://github.com/eclipse-glsp/glsp/issues",
+  "contributors": [
+    {
+      "name": "Tobias Ortmayr",
+      "email": "tortmayr@eclipsesource.com",
+      "url": "https://www.eclipsesource.com"
+    }
+  ],
   "files": [
     "lib",
     "src",
     "server"
   ],
-  "author": {
-    "name": "EclipseSource"
-  },
   "dependencies": {
     "@eclipse-glsp-examples/workflow-glsp": "next",
     "@eclipse-glsp/theia-integration": "0.9.0"
@@ -25,10 +38,11 @@
     "typescript": "^3.9.2"
   },
   "scripts": {
-    "prepare": "yarn run clean && yarn run build",
+    "prepare": "yarn  clean && yarn  build && yarn lint",
     "clean": "rimraf lib",
-    "build": "tsc && yarn run lint",
+    "build": "tsc",
     "lint": "eslint -c ./.eslintrc.js --ext .ts,.tsx ./src",
+    "build:ci": "yarn clean && yarn build -o eslint.xml -f checkstyle",
     "watch": "tsc -w"
   },
   "publishConfig": {

--- a/examples/workflow-theia/src/browser/diagram/workflow-diagram-configuration.ts
+++ b/examples/workflow-theia/src/browser/diagram/workflow-diagram-configuration.ts
@@ -19,7 +19,7 @@ import { createWorkflowDiagramContainer } from '@eclipse-glsp-examples/workflow-
 import {
     GLSPTheiaDiagramConfiguration
 } from '@eclipse-glsp/theia-integration/lib/browser/diagram/glsp-theia-diagram-configuration';
-import { Container, injectable } from 'inversify';
+import { Container, injectable } from '@theia/core/shared/inversify';
 
 import { WorkflowLanguage } from '../../common/workflow-language';
 import { WorkflowDiagramServer } from './workflow-diagram-server';

--- a/examples/workflow-theia/src/browser/diagram/workflow-diagram-manager.ts
+++ b/examples/workflow-theia/src/browser/diagram/workflow-diagram-manager.ts
@@ -20,8 +20,8 @@ import {
 } from '@eclipse-glsp/theia-integration/lib/browser';
 import { MessageService } from '@theia/core';
 import { WidgetManager } from '@theia/core/lib/browser';
+import { inject, injectable } from '@theia/core/shared/inversify';
 import { EditorManager } from '@theia/editor/lib/browser';
-import { inject, injectable } from 'inversify';
 import { TheiaFileSaver } from 'sprotty-theia';
 
 import { WorkflowLanguage } from '../../common/workflow-language';

--- a/examples/workflow-theia/src/browser/diagram/workflow-diagram-readonly-view.ts
+++ b/examples/workflow-theia/src/browser/diagram/workflow-diagram-readonly-view.ts
@@ -26,8 +26,8 @@ import {
 import { OpenerService } from '@theia/core/lib/browser';
 import URI from '@theia/core/lib/common/uri';
 import { UriAwareCommandHandler } from '@theia/core/lib/common/uri-command-handler';
+import { inject, injectable } from '@theia/core/shared/inversify';
 import { NavigatorContextMenu } from '@theia/navigator/lib/browser/navigator-contribution';
-import { inject, injectable } from 'inversify';
 
 export const OPEN_READONLY_DIAGRAM_VIEW: Command = {
     id: 'workflow.open.readonly',

--- a/examples/workflow-theia/src/browser/diagram/workflow-diagram-server.ts
+++ b/examples/workflow-theia/src/browser/diagram/workflow-diagram-server.ts
@@ -16,7 +16,7 @@
 import { ApplyTaskEditOperation } from '@eclipse-glsp-examples/workflow-glsp/lib/direct-task-editing/direct-task-editor';
 import { ActionHandlerRegistry } from '@eclipse-glsp/client';
 import { GLSPTheiaDiagramServer } from '@eclipse-glsp/theia-integration/lib/browser';
-import { injectable } from 'inversify';
+import { injectable } from '@theia/core/shared/inversify';
 
 @injectable()
 export class WorkflowDiagramServer extends GLSPTheiaDiagramServer {

--- a/examples/workflow-theia/src/browser/diagram/workflow-glsp-diagram-client.ts
+++ b/examples/workflow-theia/src/browser/diagram/workflow-glsp-diagram-client.ts
@@ -14,8 +14,8 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 import { GLSPDiagramClient } from '@eclipse-glsp/theia-integration/lib/browser';
+import { inject, injectable } from '@theia/core/shared/inversify';
 import { EditorManager } from '@theia/editor/lib/browser';
-import { inject, injectable } from 'inversify';
 
 import { WorkflowGLSPClientContribution } from '../language/workflow-glsp-client-contribution';
 

--- a/examples/workflow-theia/src/browser/diagram/workflow-keybinding-contribution.ts
+++ b/examples/workflow-theia/src/browser/diagram/workflow-keybinding-contribution.ts
@@ -15,7 +15,7 @@
  ********************************************************************************/
 import { GLSPDiagramWidget } from '@eclipse-glsp/theia-integration/lib/browser';
 import { ApplicationShell, KeybindingContext, KeybindingContribution, KeybindingRegistry } from '@theia/core/lib/browser';
-import { inject, injectable } from 'inversify';
+import { inject, injectable } from '@theia/core/shared/inversify';
 
 import { WorkflowLanguage } from '../../common/workflow-language';
 import { WorkflowNavigationCommands } from './workflow-navigation-context-menu';

--- a/examples/workflow-theia/src/browser/diagram/workflow-navigation-context-menu.ts
+++ b/examples/workflow-theia/src/browser/diagram/workflow-navigation-context-menu.ts
@@ -18,7 +18,7 @@ import { NavigateAction } from '@eclipse-glsp/client';
 import { GLSPCommandHandler, GLSPContextMenu } from '@eclipse-glsp/theia-integration/lib/browser';
 import { CommandContribution, CommandRegistry, MenuContribution, MenuModelRegistry } from '@theia/core';
 import { ApplicationShell } from '@theia/core/lib/browser';
-import { inject, injectable } from 'inversify';
+import { inject, injectable } from '@theia/core/shared/inversify';
 
 export namespace WorkflowNavigationCommands {
     export const NEXT_NODE = 'glsp-workflow-next-node';

--- a/examples/workflow-theia/src/browser/diagram/workflow-task-editing-context-menu.ts
+++ b/examples/workflow-theia/src/browser/diagram/workflow-task-editing-context-menu.ts
@@ -19,7 +19,7 @@ import { SetUIExtensionVisibilityAction } from '@eclipse-glsp/client';
 import { GLSPCommandHandler, GLSPContextMenu } from '@eclipse-glsp/theia-integration/lib/browser';
 import { CommandContribution, CommandRegistry, MenuContribution, MenuModelRegistry } from '@theia/core';
 import { ApplicationShell } from '@theia/core/lib/browser';
-import { inject, injectable } from 'inversify';
+import { inject, injectable } from '@theia/core/shared/inversify';
 
 export namespace WorkflowTaskEditingCommands {
     export const EDIT_TASK = 'glsp-workflow-edit-task';

--- a/examples/workflow-theia/src/browser/external-navigation-example/external-navigation-example.ts
+++ b/examples/workflow-theia/src/browser/external-navigation-example/external-navigation-example.ts
@@ -16,8 +16,8 @@
 import { CommandContribution, CommandRegistry } from '@theia/core';
 import { open, OpenerService } from '@theia/core/lib/browser/opener-service';
 import URI from '@theia/core/lib/common/uri';
+import { inject, injectable } from '@theia/core/shared/inversify';
 import { WorkspaceService } from '@theia/workspace/lib/browser/workspace-service';
-import { inject, injectable } from 'inversify';
 
 @injectable()
 export class ExampleNavigationCommandContribution implements CommandContribution {

--- a/examples/workflow-theia/src/browser/language/workflow-glsp-client-contribution.ts
+++ b/examples/workflow-theia/src/browser/language/workflow-glsp-client-contribution.ts
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 import { BaseGLSPClientContribution } from '@eclipse-glsp/theia-integration/lib/browser';
-import { injectable } from 'inversify';
+import { injectable } from '@theia/core/shared/inversify';
 
 import { WorkflowLanguage } from '../../common/workflow-language';
 

--- a/examples/workflow-theia/src/browser/workflow-frontend-module.ts
+++ b/examples/workflow-theia/src/browser/workflow-frontend-module.ts
@@ -22,7 +22,7 @@ import {
 } from '@eclipse-glsp/theia-integration/lib/browser';
 import { CommandContribution, MenuContribution } from '@theia/core';
 import { KeybindingContext, KeybindingContribution } from '@theia/core/lib/browser';
-import { ContainerModule, interfaces } from 'inversify';
+import { ContainerModule, interfaces } from '@theia/core/shared/inversify';
 import { DiagramConfiguration } from 'sprotty-theia';
 
 import { WorkflowDiagramConfiguration } from './diagram/workflow-diagram-configuration';

--- a/examples/workflow-theia/src/node/workflow-backend-module.ts
+++ b/examples/workflow-theia/src/node/workflow-backend-module.ts
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 import { GLSPServerContribution } from '@eclipse-glsp/theia-integration/lib/node';
-import { ContainerModule } from 'inversify';
+import { ContainerModule } from '@theia/core/shared/inversify';
 
 import { WorkflowGLServerContribution } from './workflow-glsp-server-contribution';
 

--- a/examples/workflow-theia/src/node/workflow-glsp-server-contribution.ts
+++ b/examples/workflow-theia/src/node/workflow-glsp-server-contribution.ts
@@ -15,7 +15,7 @@
  ********************************************************************************/
 import { getPort } from '@eclipse-glsp/protocol';
 import { JavaSocketServerContribution, JavaSocketServerLaunchOptions } from '@eclipse-glsp/theia-integration/lib/node';
-import { injectable } from 'inversify';
+import { injectable } from '@theia/core/shared/inversify';
 import { join, resolve } from 'path';
 
 import { WorkflowLanguage } from '../common/workflow-language';

--- a/package.json
+++ b/package.json
@@ -10,11 +10,13 @@
     "test": "yarn",
     "prepare": "lerna run prepare",
     "watch": "lerna run --parallel watch",
+    "build": "yarn install --ignore-scripts && lerna run build",
+    "lint": "lerna run lint --",
     "rebuild:browser": "theia rebuild:browser",
-    "publish": "yarn && yarn publish:latest",
     "publish:latest": "lerna publish",
     "publish:next": "lerna publish --exact --canary=next --npm-tag=next --yes",
     "upgrade:next": "yarn upgrade -p \"sprotty-theia|@eclipse-glsp.*\" --next ",
+    "build:ci": "lerna run build:ci",
     "download:exampleServer": "ts-node examples/workflow-theia/server/download.ts"
   },
   "devDependencies": {

--- a/packages/theia-integration/package.json
+++ b/packages/theia-integration/package.json
@@ -17,15 +17,22 @@
     "glsp",
     "diagram editor"
   ],
-  "homepage": "https://www.eclipse.org/glsp",
-  "bugs": "https://github.com/eclipse-glsp/glsp-theia-integration/issues",
   "author": {
-    "name": "EclipseSource"
+    "name": "Eclipse GLSP"
   },
+  "homepage": "https://www.eclipse.org/glsp/",
   "repository": {
     "type": "git",
     "url": "https://github.com/eclipse-glsp/glsp-theia-integration.git"
   },
+  "bugs": "https://github.com/eclipse-glsp/glsp/issues",
+  "contributors": [
+    {
+      "name": "Tobias Ortmayr",
+      "email": "tortmayr@eclipsesource.com",
+      "url": "https://www.eclipsesource.com"
+    }
+  ],
   "files": [
     "lib",
     "src",
@@ -42,10 +49,11 @@
     "typescript": "^3.9.2"
   },
   "scripts": {
-    "prepare": "yarn run clean && yarn run build",
+    "prepare": "yarn  clean && yarn  build",
     "clean": "rimraf lib",
-    "build": "tsc && yarn run lint",
+    "build": "tsc",
     "lint": "eslint -c ./.eslintrc.js --ext .ts ./src",
+    "build:ci": "yarn clean && yarn build -o eslint.xml -f checkstyle",
     "watch": "tsc -w"
   },
   "theiaExtensions": [

--- a/packages/theia-integration/src/browser/diagram/glsp-diagram-client.ts
+++ b/packages/theia-integration/src/browser/diagram/glsp-diagram-client.ts
@@ -16,8 +16,8 @@
 import { GLSPClient } from '@eclipse-glsp/protocol';
 import { CommandRegistry } from '@theia/core';
 import { ApplicationShell } from '@theia/core/lib/browser';
+import { inject, injectable } from '@theia/core/shared/inversify';
 import { EditorManager } from '@theia/editor/lib/browser';
-import { inject, injectable } from 'inversify';
 import { ActionMessage } from 'sprotty';
 
 import { GLSPClientContribution } from '../glsp-client-contribution';

--- a/packages/theia-integration/src/browser/diagram/glsp-diagram-context-key-service.ts
+++ b/packages/theia-integration/src/browser/diagram/glsp-diagram-context-key-service.ts
@@ -27,7 +27,7 @@ import {
 import { SelectionService } from '@eclipse-glsp/client/lib/features/select/selection-service';
 import { ApplicationShell } from '@theia/core/lib/browser';
 import { ContextKey, ContextKeyService } from '@theia/core/lib/browser/context-key-service';
-import { inject, injectable, postConstruct } from 'inversify';
+import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
 import { isDiagramWidgetContainer } from 'sprotty-theia';
 
 import { GLSPDiagramWidget } from './glsp-diagram-widget';

--- a/packages/theia-integration/src/browser/diagram/glsp-diagram-layout-commands.ts
+++ b/packages/theia-integration/src/browser/diagram/glsp-diagram-layout-commands.ts
@@ -26,7 +26,7 @@ import {
 } from '@eclipse-glsp/client';
 import { CommandContribution, CommandRegistry, MenuContribution, MenuModelRegistry, MenuPath } from '@theia/core';
 import { ApplicationShell, KeybindingContribution, KeybindingRegistry } from '@theia/core/lib/browser';
-import { inject, injectable, interfaces } from 'inversify';
+import { inject, injectable, interfaces } from '@theia/core/shared/inversify';
 import { DiagramKeybindingContext, DiagramMenus } from 'sprotty-theia';
 
 import { GLSPCommandHandler } from './glsp-command-handler';

--- a/packages/theia-integration/src/browser/diagram/glsp-diagram-manager.ts
+++ b/packages/theia-integration/src/browser/diagram/glsp-diagram-manager.ts
@@ -24,8 +24,8 @@ import {
 } from '@theia/core/lib/browser';
 import { SelectionService } from '@theia/core/lib/common/selection-service';
 import URI from '@theia/core/lib/common/uri';
+import { inject, injectable, interfaces } from '@theia/core/shared/inversify';
 import { EditorPreferences } from '@theia/editor/lib/browser';
-import { inject, injectable, interfaces } from 'inversify';
 import {
     DiagramConfiguration,
     DiagramManager,

--- a/packages/theia-integration/src/browser/diagram/glsp-diagram-widget.ts
+++ b/packages/theia-integration/src/browser/diagram/glsp-diagram-widget.ts
@@ -13,7 +13,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
- import {
+import {
     Args,
     DiagramServer,
     DisposeClientSessionAction,
@@ -37,8 +37,8 @@ import { Message } from '@phosphor/messaging/lib';
 import { ApplicationShell, Saveable, SaveableSource, Widget } from '@theia/core/lib/browser';
 import { Disposable, DisposableCollection, Emitter, Event, MaybePromise } from '@theia/core/lib/common';
 import { SelectionService } from '@theia/core/lib/common/selection-service';
+import { Container } from '@theia/core/shared/inversify';
 import { EditorPreferences } from '@theia/editor/lib/browser';
-import { Container } from 'inversify';
 import { pickBy } from 'lodash';
 import { DiagramWidget, DiagramWidgetOptions, isDiagramWidgetContainer, TheiaSprottyConnector } from 'sprotty-theia';
 
@@ -159,9 +159,9 @@ export class GLSPDiagramWidget extends DiagramWidget implements SaveableSource {
         }));
     }
 
-    protected isThisWidget(widget: Widget | null): boolean {
+    protected isThisWidget(widget?: Widget | null): boolean {
         // eslint-disable-next-line no-null/no-null
-        if (widget === null) {
+        if (!widget || widget === null) {
             return false;
         }
         const diagramWidget = getDiagramWidget(widget);

--- a/packages/theia-integration/src/browser/diagram/glsp-selection-data-service.ts
+++ b/packages/theia-integration/src/browser/diagram/glsp-selection-data-service.ts
@@ -13,7 +13,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import { injectable } from 'inversify';
+import { injectable } from '@theia/core/shared/inversify';
 
 export interface GlspSelectionData {
     selectionDataMap: Map<string, any>;

--- a/packages/theia-integration/src/browser/diagram/glsp-theia-context-menu-service.ts
+++ b/packages/theia-integration/src/browser/diagram/glsp-theia-context-menu-service.ts
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 import { GLSP_TYPES, IActionDispatcher, TYPES } from '@eclipse-glsp/client';
-import { Container } from 'inversify';
+import { Container } from '@theia/core/shared/inversify';
 import {
     TheiaContextMenuService,
     TheiaSprottyContextMenu

--- a/packages/theia-integration/src/browser/diagram/glsp-theia-diagram-configuration.ts
+++ b/packages/theia-integration/src/browser/diagram/glsp-theia-diagram-configuration.ts
@@ -22,7 +22,7 @@ import {
 } from '@eclipse-glsp/client';
 import { CommandService, SelectionService } from '@theia/core';
 import { OpenerService } from '@theia/core/lib/browser';
-import { Container, inject, injectable } from 'inversify';
+import { Container, inject, injectable } from '@theia/core/shared/inversify';
 import { DiagramConfiguration, TheiaContextMenuService, TheiaDiagramServer } from 'sprotty-theia';
 
 import { TheiaCommandPalette } from '../theia-command-palette';

--- a/packages/theia-integration/src/browser/diagram/glsp-theia-diagram-server.ts
+++ b/packages/theia-integration/src/browser/diagram/glsp-theia-diagram-server.ts
@@ -26,7 +26,7 @@ import {
     SourceUriAware
 } from '@eclipse-glsp/client';
 import { Emitter, Event } from '@theia/core/lib/common';
-import { injectable } from 'inversify';
+import { injectable } from '@theia/core/shared/inversify';
 import { TheiaDiagramServer } from 'sprotty-theia';
 
 import { GLSPTheiaSprottyConnector } from './glsp-theia-sprotty-connector';

--- a/packages/theia-integration/src/browser/diagram/glsp-theia-marker-manager.ts
+++ b/packages/theia-integration/src/browser/diagram/glsp-theia-marker-manager.ts
@@ -15,8 +15,8 @@
  ********************************************************************************/
 import { ExternalMarkerManager, IActionDispatcher, Marker, MarkerKind, TYPES } from '@eclipse-glsp/client/lib';
 import URI from '@theia/core/lib/common/uri';
+import { Container, inject, injectable, optional, postConstruct } from '@theia/core/shared/inversify';
 import { ProblemManager } from '@theia/markers/lib/browser/problem/problem-manager';
-import { Container, inject, injectable, optional, postConstruct } from 'inversify';
 import { Diagnostic } from 'vscode-languageserver-types';
 
 import { SelectionWithElementIds } from '../theia-opener-options-navigation-service';

--- a/packages/theia-integration/src/browser/diagram/glsp-theia-selection-forwarder.ts
+++ b/packages/theia-integration/src/browser/diagram/glsp-theia-selection-forwarder.ts
@@ -13,7 +13,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import { inject, injectable, optional } from 'inversify';
+import { inject, injectable, optional } from '@theia/core/shared/inversify';
 import { Action, SelectAction } from 'sprotty';
 import { isSprottySelection, SprottySelection, TheiaSprottySelectionForwarder } from 'sprotty-theia';
 

--- a/packages/theia-integration/src/browser/glsp-client-contribution.ts
+++ b/packages/theia-integration/src/browser/glsp-client-contribution.ts
@@ -28,8 +28,8 @@ import {
 import { Disposable, DisposableCollection, MaybePromise, MessageService } from '@theia/core';
 import { FrontendApplication, WebSocketConnectionProvider } from '@theia/core/lib/browser';
 import { Deferred } from '@theia/core/lib/common/promise-util';
+import { inject, injectable, multiInject } from '@theia/core/shared/inversify';
 import { WorkspaceService } from '@theia/workspace/lib/browser';
-import { inject, injectable, multiInject } from 'inversify';
 import { DiagramManagerProvider } from 'sprotty-theia';
 import { MessageConnection } from 'vscode-jsonrpc';
 

--- a/packages/theia-integration/src/browser/glsp-client-provider.ts
+++ b/packages/theia-integration/src/browser/glsp-client-provider.ts
@@ -15,7 +15,7 @@
  ********************************************************************************/
 import { GLSPClient } from '@eclipse-glsp/protocol';
 import { ContributionProvider } from '@theia/core';
-import { inject, injectable, named } from 'inversify';
+import { inject, injectable, named } from '@theia/core/shared/inversify';
 
 import { GLSPClientContribution } from './glsp-client-contribution';
 

--- a/packages/theia-integration/src/browser/glsp-frontend-contribution.ts
+++ b/packages/theia-integration/src/browser/glsp-frontend-contribution.ts
@@ -15,7 +15,7 @@
  ********************************************************************************/
 import { ContributionProvider } from '@theia/core';
 import { FrontendApplication, FrontendApplicationContribution } from '@theia/core/lib/browser';
-import { inject, injectable, named } from 'inversify';
+import { inject, injectable, named } from '@theia/core/shared/inversify';
 
 import { GLSPClientContribution } from './glsp-client-contribution';
 

--- a/packages/theia-integration/src/browser/glsp-frontend-module.ts
+++ b/packages/theia-integration/src/browser/glsp-frontend-module.ts
@@ -15,8 +15,8 @@
  ********************************************************************************/
 import { bindContributionProvider } from '@theia/core';
 import { FrontendApplicationContribution, WebSocketConnectionProvider } from '@theia/core/lib/browser';
+import { ContainerModule } from '@theia/core/shared/inversify';
 import { NotificationManager } from '@theia/messages/lib/browser/notifications-manager';
-import { ContainerModule } from 'inversify';
 import { TheiaContextMenuService } from 'sprotty-theia/lib/sprotty/theia-sprotty-context-menu-service';
 
 import { GLSPClientContribution, GLSPClientProvider, GLSPClientProviderImpl } from '.';

--- a/packages/theia-integration/src/browser/theia-copy-paste-context-menu-contribution.ts
+++ b/packages/theia-integration/src/browser/theia-copy-paste-context-menu-contribution.ts
@@ -15,7 +15,7 @@
  ********************************************************************************/
 import { MenuContribution, MenuModelRegistry } from '@theia/core';
 import { CommonCommands } from '@theia/core/lib/browser';
-import { injectable, interfaces } from 'inversify';
+import { injectable, interfaces } from '@theia/core/shared/inversify';
 import { TheiaSprottyContextMenu } from 'sprotty-theia';
 
 export function registerCopyPasteContextMenu(bind: interfaces.Bind): void {

--- a/packages/theia-integration/src/browser/theia-model-source-changed-handler.ts
+++ b/packages/theia-integration/src/browser/theia-model-source-changed-handler.ts
@@ -15,7 +15,7 @@
  ********************************************************************************/
 import { Action, ExternalModelSourceChangedHandler, ViewerOptions } from '@eclipse-glsp/client';
 import { ApplicationShell, ConfirmDialog, Widget } from '@theia/core/lib/browser';
-import { inject, injectable } from 'inversify';
+import { inject, injectable } from '@theia/core/shared/inversify';
 
 import { getDiagramWidget } from './diagram/glsp-diagram-widget';
 

--- a/packages/theia-integration/src/browser/theia-navigate-to-external-target-handler.ts
+++ b/packages/theia-integration/src/browser/theia-navigate-to-external-target-handler.ts
@@ -16,7 +16,7 @@
 import { Action, Args, IActionHandler, isNavigateToExternalTargetAction } from '@eclipse-glsp/client/lib';
 import { open, OpenerService } from '@theia/core/lib/browser/opener-service';
 import URI from '@theia/core/lib/common/uri';
-import { inject, injectable } from 'inversify';
+import { inject, injectable } from '@theia/core/shared/inversify';
 
 @injectable()
 export class TheiaNavigateToExternalTargetHandler implements IActionHandler {

--- a/packages/theia-integration/src/browser/theia-navigate-to-marker-contribution.ts
+++ b/packages/theia-integration/src/browser/theia-navigate-to-marker-contribution.ts
@@ -16,7 +16,7 @@
 import { collectIssueMarkers, NavigateToMarkerAction } from '@eclipse-glsp/client/lib';
 import { CommandContribution, CommandRegistry, MenuContribution, MenuModelRegistry } from '@theia/core';
 import { ApplicationShell, KeybindingContribution, KeybindingRegistry } from '@theia/core/lib/browser';
-import { inject, injectable, interfaces } from 'inversify';
+import { inject, injectable, interfaces } from '@theia/core/shared/inversify';
 import { DiagramKeybindingContext } from 'sprotty-theia';
 
 import { GLSPCommandHandler } from './diagram/glsp-command-handler';

--- a/packages/theia-integration/src/browser/theia-opener-options-navigation-service.ts
+++ b/packages/theia-integration/src/browser/theia-opener-options-navigation-service.ts
@@ -15,8 +15,8 @@
  ********************************************************************************/
 import { NavigateToTargetAction, NavigationTarget } from '@eclipse-glsp/client/lib';
 import { OpenerOptions } from '@theia/core/lib/browser';
+import { injectable } from '@theia/core/shared/inversify';
 import { Range } from '@theia/editor/lib/browser';
-import { injectable } from 'inversify';
 
 /**
  * Service for translating `OpenerOptions` into a `NavigateToTargetAction`.

--- a/packages/theia-integration/src/node/glsp-backend-contribution.ts
+++ b/packages/theia-integration/src/node/glsp-backend-contribution.ts
@@ -15,7 +15,7 @@
  ********************************************************************************/
 import { ContributionProvider, ILogger } from '@theia/core/lib/common';
 import { MessagingService } from '@theia/core/lib/node/messaging/messaging-service';
-import { inject, injectable, named } from 'inversify';
+import { inject, injectable, named } from '@theia/core/shared/inversify';
 
 import { GLSPContribution } from '../common';
 import { GLSPServerContribution, GLSPServerLaunchOptions } from './glsp-server-contribution';

--- a/packages/theia-integration/src/node/glsp-backend-module.ts
+++ b/packages/theia-integration/src/node/glsp-backend-module.ts
@@ -15,7 +15,7 @@
  ********************************************************************************/
 import { bindContributionProvider, ConnectionHandler, ILogger, JsonRpcConnectionHandler } from '@theia/core/lib/common';
 import { MessagingService } from '@theia/core/lib/node/messaging/messaging-service';
-import { ContainerModule } from 'inversify';
+import { ContainerModule } from '@theia/core/shared/inversify';
 
 import { GLSPContribution } from '../common';
 import { GLSPBackendContribution } from './glsp-backend-contribution';

--- a/packages/theia-integration/src/node/glsp-server-contribution.ts
+++ b/packages/theia-integration/src/node/glsp-server-contribution.ts
@@ -15,11 +15,11 @@
  ********************************************************************************/
 import { MaybePromise } from '@eclipse-glsp/protocol';
 import { WebSocketChannelConnection } from '@theia/core/lib/node/messaging';
+import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
 import { ProcessErrorEvent } from '@theia/process/lib/node/process';
 import { ProcessManager } from '@theia/process/lib/node/process-manager';
 import { RawProcess, RawProcessFactory } from '@theia/process/lib/node/raw-process';
 import * as cp from 'child_process';
-import { inject, injectable, postConstruct } from 'inversify';
 import { forward, IConnection } from 'vscode-ws-jsonrpc/lib/server';
 
 import { GLSPContribution } from '../common';

--- a/packages/theia-integration/src/node/java-socket-glsp-server.ts
+++ b/packages/theia-integration/src/node/java-socket-glsp-server.ts
@@ -13,8 +13,8 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
+import { injectable, postConstruct } from '@theia/core/shared/inversify';
 import * as fs from 'fs';
-import { injectable, postConstruct } from 'inversify';
 import * as net from 'net';
 import { createSocketConnection, IConnection } from 'vscode-ws-jsonrpc/lib/server';
 


### PR DESCRIPTION
Typescript
- Use reexported inversify version from Theia to ensure future stable builds
- Fix es-lint violation in `glsp-diagram-widget.ts`

Package.json
- Introduce dedicated build script for `build` and `lint`

Jenkinsfile
- Refactor build stage
- Introduce eslint stage + enable recording & publishing of issues
- Only trigger deployment job if public package code was changed 
 (part of eclipse-glsp/glsp/issues/229)

Part of: eclipse-glsp/glsp/issues/60