### PR TITLE
#377 Update to latest glsp-config version

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -32,6 +32,9 @@
   "[javascript]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
+  "[javascriptreact]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
   "[markdown]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },

--- a/examples/workflow-theia/src/browser/diagram/workflow-diagram-readonly-view.ts
+++ b/examples/workflow-theia/src/browser/diagram/workflow-diagram-readonly-view.ts
@@ -15,14 +15,7 @@
  ********************************************************************************/
 import { EditMode } from '@eclipse-glsp/client';
 import { GLSPWidgetOpenerOptions } from '@eclipse-glsp/theia-integration';
-import {
-    Command,
-    CommandContribution,
-    CommandRegistry,
-    MenuContribution,
-    MenuModelRegistry,
-    SelectionService
-} from '@theia/core';
+import { Command, CommandContribution, CommandRegistry, MenuContribution, MenuModelRegistry, SelectionService } from '@theia/core';
 import { OpenerService } from '@theia/core/lib/browser';
 import URI from '@theia/core/lib/common/uri';
 import { UriAwareCommandHandler } from '@theia/core/lib/common/uri-command-handler';
@@ -34,7 +27,6 @@ export const OPEN_READONLY_DIAGRAM_VIEW: Command = {
     label: 'Open in Workflow Diagram Readonly View',
     category: '2_additional',
     iconClass: 'fa fa-project-diagram'
-
 };
 @injectable()
 export class WorkflowDiagramReadonlyViewContribution implements CommandContribution, MenuContribution {
@@ -49,14 +41,17 @@ export class WorkflowDiagramReadonlyViewContribution implements CommandContribut
     }
 
     registerCommands(registry: CommandRegistry): void {
-        registry.registerCommand(OPEN_READONLY_DIAGRAM_VIEW, new UriAwareCommandHandler(this.selectionService, {
-            execute: async (uri: URI) => {
-                const openerOptions: GLSPWidgetOpenerOptions = { editMode: EditMode.READONLY };
-                const opener = await this.openerService.getOpener(uri, openerOptions);
-                await opener.open(uri, openerOptions);
-            },
-            isVisible: uri => uri.toString().endsWith('.wf'),
-            isEnabled: uri => uri.toString().endsWith('.wf')
-        }));
+        registry.registerCommand(
+            OPEN_READONLY_DIAGRAM_VIEW,
+            new UriAwareCommandHandler(this.selectionService, {
+                execute: async (uri: URI) => {
+                    const openerOptions: GLSPWidgetOpenerOptions = { editMode: EditMode.READONLY };
+                    const opener = await this.openerService.getOpener(uri, openerOptions);
+                    await opener.open(uri, openerOptions);
+                },
+                isVisible: uri => uri.toString().endsWith('.wf'),
+                isEnabled: uri => uri.toString().endsWith('.wf')
+            })
+        );
     }
 }

--- a/examples/workflow-theia/src/browser/diagram/workflow-keybinding-contribution.ts
+++ b/examples/workflow-theia/src/browser/diagram/workflow-keybinding-contribution.ts
@@ -26,8 +26,7 @@ export class WorkflowDiagramKeybindingContext implements KeybindingContext {
     id = WorkflowDiagramKeybindingContext.ID;
     @inject(ApplicationShell) protected readonly shell: ApplicationShell;
     isEnabled(): boolean {
-        return this.shell.activeWidget instanceof GLSPDiagramWidget
-            && this.shell.activeWidget.diagramType === WorkflowLanguage.diagramType;
+        return this.shell.activeWidget instanceof GLSPDiagramWidget && this.shell.activeWidget.diagramType === WorkflowLanguage.diagramType;
     }
 }
 

--- a/examples/workflow-theia/src/browser/diagram/workflow-navigation-context-menu.ts
+++ b/examples/workflow-theia/src/browser/diagram/workflow-navigation-context-menu.ts
@@ -30,19 +30,22 @@ export namespace WorkflowNavigationCommands {
 export class WorkflowNavigationCommandContribution implements CommandContribution {
     @inject(ApplicationShell) protected readonly shell: ApplicationShell;
     registerCommands(commands: CommandRegistry): void {
-        commands.registerCommand({ id: WorkflowNavigationCommands.NEXT_NODE, label: 'Go to Next Node' },
+        commands.registerCommand(
+            { id: WorkflowNavigationCommands.NEXT_NODE, label: 'Go to Next Node' },
             new GLSPCommandHandler(this.shell, {
                 actions: () => [new NavigateAction('next')],
                 isEnabled: context => context.selectedElements.filter(isTaskNode).length === 1
             })
         );
-        commands.registerCommand({ id: WorkflowNavigationCommands.PREVIOUS_NODE, label: 'Go to Previous Node' },
+        commands.registerCommand(
+            { id: WorkflowNavigationCommands.PREVIOUS_NODE, label: 'Go to Previous Node' },
             new GLSPCommandHandler(this.shell, {
                 actions: () => [new NavigateAction('previous')],
                 isEnabled: context => context.selectedElements.filter(isTaskNode).length === 1
             })
         );
-        commands.registerCommand({ id: WorkflowNavigationCommands.DOCUMENTATION, label: 'Go to Documentation' },
+        commands.registerCommand(
+            { id: WorkflowNavigationCommands.DOCUMENTATION, label: 'Go to Documentation' },
             new GLSPCommandHandler(this.shell, {
                 actions: () => [new NavigateAction('documentation')],
                 isEnabled: context => context.selectedElements.filter(isTaskNode).length === 1
@@ -55,8 +58,17 @@ export class WorkflowNavigationCommandContribution implements CommandContributio
 export class WorkflowNavigationMenuContribution implements MenuContribution {
     static readonly NAVIGATION = GLSPContextMenu.MENU_PATH.concat('navigate');
     registerMenus(menus: MenuModelRegistry): void {
-        menus.registerMenuAction(WorkflowNavigationMenuContribution.NAVIGATION.concat('n'), { commandId: WorkflowNavigationCommands.NEXT_NODE, label: 'Next node' });
-        menus.registerMenuAction(WorkflowNavigationMenuContribution.NAVIGATION.concat('n'), { commandId: WorkflowNavigationCommands.PREVIOUS_NODE, label: 'Previous node' });
-        menus.registerMenuAction(WorkflowNavigationMenuContribution.NAVIGATION.concat('z'), { commandId: WorkflowNavigationCommands.DOCUMENTATION, label: 'Documentation' });
+        menus.registerMenuAction(WorkflowNavigationMenuContribution.NAVIGATION.concat('n'), {
+            commandId: WorkflowNavigationCommands.NEXT_NODE,
+            label: 'Next node'
+        });
+        menus.registerMenuAction(WorkflowNavigationMenuContribution.NAVIGATION.concat('n'), {
+            commandId: WorkflowNavigationCommands.PREVIOUS_NODE,
+            label: 'Previous node'
+        });
+        menus.registerMenuAction(WorkflowNavigationMenuContribution.NAVIGATION.concat('z'), {
+            commandId: WorkflowNavigationCommands.DOCUMENTATION,
+            label: 'Documentation'
+        });
     }
 }

--- a/examples/workflow-theia/src/browser/diagram/workflow-task-editing-context-menu.ts
+++ b/examples/workflow-theia/src/browser/diagram/workflow-task-editing-context-menu.ts
@@ -29,7 +29,8 @@ export namespace WorkflowTaskEditingCommands {
 export class WorkflowTaskEditCommandContribution implements CommandContribution {
     @inject(ApplicationShell) protected readonly shell: ApplicationShell;
     registerCommands(commands: CommandRegistry): void {
-        commands.registerCommand({ id: WorkflowTaskEditingCommands.EDIT_TASK, label: 'Direct Edit Task' },
+        commands.registerCommand(
+            { id: WorkflowTaskEditingCommands.EDIT_TASK, label: 'Direct Edit Task' },
             new GLSPCommandHandler(this.shell, {
                 actions: context => [new SetUIExtensionVisibilityAction(TaskEditor.ID, true, [context.selectedElements[0].id])],
                 isEnabled: context => !context.isReadonly && context.selectedElements.filter(isTaskNode).length === 1

--- a/examples/workflow-theia/src/browser/workflow-frontend-module.ts
+++ b/examples/workflow-theia/src/browser/workflow-frontend-module.ts
@@ -21,18 +21,9 @@ import { DiagramConfiguration } from 'sprotty-theia';
 import { WorkflowLanguage } from '../common/workflow-language';
 import { WorkflowDiagramConfiguration } from './diagram/workflow-diagram-configuration';
 import { WorkflowDiagramReadonlyViewContribution } from './diagram/workflow-diagram-readonly-view';
-import {
-    WorkflowDiagramKeybindingContext,
-    WorkflowKeybindingContribution
-} from './diagram/workflow-keybinding-contribution';
-import {
-    WorkflowNavigationCommandContribution,
-    WorkflowNavigationMenuContribution
-} from './diagram/workflow-navigation-context-menu';
-import {
-    WorkflowTaskEditCommandContribution,
-    WorkflowTaskEditMenuContribution
-} from './diagram/workflow-task-editing-context-menu';
+import { WorkflowDiagramKeybindingContext, WorkflowKeybindingContribution } from './diagram/workflow-keybinding-contribution';
+import { WorkflowNavigationCommandContribution, WorkflowNavigationMenuContribution } from './diagram/workflow-navigation-context-menu';
+import { WorkflowTaskEditCommandContribution, WorkflowTaskEditMenuContribution } from './diagram/workflow-task-editing-context-menu';
 import { ExampleNavigationCommandContribution } from './external-navigation-example/external-navigation-example';
 import { WorkflowGLSPClientContribution } from './workflow-glsp-client-contribution';
 
@@ -65,8 +56,6 @@ export class WorkflowTheiaFrontendModule extends GLSPTheiaFrontendModule {
     bindGLSPClientContribution(context: ContainerContext): void {
         context.bind(GLSPClientContribution).to(WorkflowGLSPClientContribution);
     }
-
 }
 
 export default new WorkflowTheiaFrontendModule();
-

--- a/examples/workflow-theia/src/node/workflow-glsp-server-contribution.ts
+++ b/examples/workflow-theia/src/node/workflow-glsp-server-contribution.ts
@@ -32,9 +32,7 @@ export class WorkflowGLServerContribution extends JavaSocketServerContribution {
     createLaunchOptions(): Partial<JavaSocketServerLaunchOptions> {
         return {
             jarPath: JAR_FILE,
-            additionalArgs: ['--consoleLog', 'false',
-                '--fileLog', 'true',
-                '--logDir', SERVER_DIR],
+            additionalArgs: ['--consoleLog', 'false', '--fileLog', 'true', '--logDir', SERVER_DIR],
             socketConnectionOptions: {
                 port: getPort(PORT_ARG_KEY, DEFAULT_PORT)
             }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "parent",
   "version": "0.9.0",
   "engines": {
-    "yarn": "1.0.x || >=1.2.1",
+    "yarn": ">=1.7.0 <2.x.x",
     "node": ">=12.14.1 <13"
   },
   "scripts": {
@@ -24,7 +24,7 @@
     "@wdio/mocha-framework": "^6.0.13",
     "@wdio/selenium-standalone-service": "^6.0.12",
     "@wdio/sync": "^6.0.14",
-    "@eclipse-glsp/config": "0.9.0-next.9648217c",
+    "@eclipse-glsp/config": "0.9.0-next.0e05932b",
     "lerna": "^2.2.0",
     "typescript": "^3.9.2"
   },

--- a/packages/theia-integration/src/browser/diagram/glsp-diagram-context-key-service.ts
+++ b/packages/theia-integration/src/browser/diagram/glsp-diagram-context-key-service.ts
@@ -31,7 +31,6 @@ import { inject, injectable, postConstruct } from '@theia/core/shared/inversify'
 import { isDiagramWidgetContainer } from 'sprotty-theia';
 import { GLSPDiagramWidget } from './glsp-diagram-widget';
 
-
 @injectable()
 export abstract class AbstractGLSPDiagramContextKeyService {
     @inject(ApplicationShell)

--- a/packages/theia-integration/src/browser/glsp-client-contribution.ts
+++ b/packages/theia-integration/src/browser/glsp-client-contribution.ts
@@ -110,7 +110,7 @@ export abstract class BaseGLSPClientContribution implements GLSPClientContributi
     activate(): Disposable {
         if (this.toDeactivate.disposed) {
             // eslint-disable-next-line @typescript-eslint/no-empty-function
-            this.toDeactivate.push(new DisposableCollection(Disposable.create(() => { }))); // mark as not disposed
+            this.toDeactivate.push(new DisposableCollection(Disposable.create(() => {}))); // mark as not disposed
             this.doActivate(this.toDeactivate);
         }
         return this.toDeactivate;
@@ -208,7 +208,7 @@ export abstract class BaseGLSPClientContribution implements GLSPClientContributi
         const doesContain = await this.workspaceService.containsSome(this.workspaceContains);
         if (!doesContain) {
             // eslint-disable-next-line @typescript-eslint/no-empty-function
-            return new Promise(resolve => { });
+            return new Promise(resolve => {});
         }
         return doesContain;
     }

--- a/packages/theia-integration/src/node/glsp-server-contribution.ts
+++ b/packages/theia-integration/src/node/glsp-server-contribution.ts
@@ -13,6 +13,8 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
+/* eslint-disable indent */
+
 import { MaybePromise } from '@eclipse-glsp/protocol';
 import { WebSocketChannelConnection } from '@theia/core/lib/node/messaging';
 import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
@@ -21,7 +23,6 @@ import { ProcessManager } from '@theia/process/lib/node/process-manager';
 import { RawProcess, RawProcessFactory } from '@theia/process/lib/node/raw-process';
 import * as cp from 'child_process';
 import { forward, IConnection } from 'vscode-ws-jsonrpc/lib/server';
-
 import { GLSPContribution } from '../common';
 
 export const GLSPServerContribution = Symbol.for('GLSPServerContribution');
@@ -47,7 +48,8 @@ export interface GLSPServerContribution extends GLSPContribution {
 export interface GLSPServerLaunchOptions {
     /**
      * Declares if the server can handle multiple clients.
-     * A `multiClient` server only has to be started once whereas in a `singleClient` scenario a new server needs to be launched for each client.
+     * A `multiClient` server only has to be started once whereas in a `singleClient` scenario a new server needs to be launched for each
+     * client.
      */
     multiClient: boolean;
     /** Declares wether the  server should be launched on application start or on demand (e.g. on widget open). */

--- a/packages/theia-integration/src/node/java-socket-glsp-server.ts
+++ b/packages/theia-integration/src/node/java-socket-glsp-server.ts
@@ -17,7 +17,6 @@ import { injectable, postConstruct } from '@theia/core/shared/inversify';
 import * as fs from 'fs';
 import * as net from 'net';
 import { createSocketConnection, IConnection } from 'vscode-ws-jsonrpc/lib/server';
-
 import { BaseGLSPServerContribution, GLSPServerLaunchOptions } from './glsp-server-contribution';
 
 export const START_UP_COMPLETE_MSG = '[GLSP-Server]:Startup completed';
@@ -115,6 +114,7 @@ export abstract class JavaSocketServerContribution extends BaseGLSPServerContrib
     protected connectToSocketServer(clientConnection: IConnection): void {
         if (isNaN(this.launchOptions.socketConnectionOptions.port)) {
             throw new Error(
+                // eslint-disable-next-line max-len
                 `Could not connect to to GLSP Server. The given server port is not a number: ${this.launchOptions.socketConnectionOptions.port}`
             );
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -909,19 +909,19 @@
     autocompleter "5.1.0"
     sprotty next
 
-"@eclipse-glsp/config@0.9.0-next.9648217c":
-  version "0.9.0-next.9648217c"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp/config/-/config-0.9.0-next.9648217c.tgz#4cd4ed484aa8e30cfd2bfa6196c8cddd3fd3ef67"
-  integrity sha512-u7Xu0//rKYrr+89pQYtRR86ZQt1Ey+m/nwY7OeowAJaeZdE/0fnaBUA71FTP86qS/Sht9Ec+GVGpQh6+T2v3mw==
+"@eclipse-glsp/config@0.9.0-next.0e05932b":
+  version "0.9.0-next.0e05932b"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp/config/-/config-0.9.0-next.0e05932b.tgz#e491200537236d39d07b6c44640748a865f311f9"
+  integrity sha512-2umAyVWSyazzNNgIvvqci1vwTjvItLLBaLldaG4nMiSzjPS4bDTf1Y4etNtb6pdmtZ2IgJcFg03bXBWOGzCYvw==
   dependencies:
-    "@eclipse-glsp/eslint-config" "0.9.0-next.9648217c"
-    "@eclipse-glsp/prettier-config" "0.9.0-next.9648217c"
-    "@eclipse-glsp/ts-config" "0.9.0-next.9648217c"
+    "@eclipse-glsp/eslint-config" "0.9.0-next.0e05932b"
+    "@eclipse-glsp/prettier-config" "0.9.0-next.0e05932b"
+    "@eclipse-glsp/ts-config" "0.9.0-next.0e05932b"
 
-"@eclipse-glsp/eslint-config@0.9.0-next.9648217c":
-  version "0.9.0-next.9648217c"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp/eslint-config/-/eslint-config-0.9.0-next.9648217c.tgz#5f9e12653f646bebe7ae0a7a4fe00bfb187b8cb3"
-  integrity sha512-QRotLPdimHm70NWrr1TabJOgEEGHKqtt4RRtKUxsgjLwLEYKPKi2vnz0Oc9RPhCVoTsraOuzpyr/1jWJZY0grw==
+"@eclipse-glsp/eslint-config@0.9.0-next.0e05932b":
+  version "0.9.0-next.0e05932b"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp/eslint-config/-/eslint-config-0.9.0-next.0e05932b.tgz#8ed0092ed55027f18fc886c99fed4f84800f84ea"
+  integrity sha512-wBcqs/ncUSirIjiewoGWvwlAYBJjUUwNu5+vOlNWYsO1xW4xu+tuuIJ5jolmMcHpONa/TQws1B7MB1oLw3cWlA==
   dependencies:
     "@typescript-eslint/eslint-plugin" "^4.32.0"
     "@typescript-eslint/parser" "^4.32.0"
@@ -931,10 +931,10 @@
     eslint-plugin-import "^2.24.2"
     eslint-plugin-no-null "^1.0.2"
 
-"@eclipse-glsp/prettier-config@0.9.0-next.9648217c":
-  version "0.9.0-next.9648217c"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp/prettier-config/-/prettier-config-0.9.0-next.9648217c.tgz#d346ca86f59b5dc17f2721d31a1dda67864da783"
-  integrity sha512-GKpJp4HrDw66dzqA1RSPt1AjXFSEhtlHi10pSw3BfBqoRrXstTSwIOYwK0oAFz6R4ORE3WL5r5O4kQaS/CnANQ==
+"@eclipse-glsp/prettier-config@0.9.0-next.0e05932b":
+  version "0.9.0-next.0e05932b"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp/prettier-config/-/prettier-config-0.9.0-next.0e05932b.tgz#83469b5638673418cbb901df9710e31df1ab7f4b"
+  integrity sha512-xcpZ8qxhSAMocFKnKMRsGmMdFXUb9bvN5U2qBZJNqn4Oe5EB7hpJNkugUXHZODo15P4WgkSZXS9vPjCus90wqQ==
 
 "@eclipse-glsp/protocol@0.9.0-next.c5944e10":
   version "0.9.0-next.c5944e10"
@@ -944,10 +944,10 @@
     uuid "7.0.3"
     vscode-ws-jsonrpc "0.2.0"
 
-"@eclipse-glsp/ts-config@0.9.0-next.9648217c":
-  version "0.9.0-next.9648217c"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp/ts-config/-/ts-config-0.9.0-next.9648217c.tgz#20a07d7105d2854ae838f7be95242fe6158ea80b"
-  integrity sha512-ZZ2HQ7S5p4EELJRxpzHxyd0hitH9y54Uf54E1RPwQPDcWR7Z1s7SK6y/CoRBs2SQ6vzEjG2WV/j21ULt34G8rQ==
+"@eclipse-glsp/ts-config@0.9.0-next.0e05932b":
+  version "0.9.0-next.0e05932b"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp/ts-config/-/ts-config-0.9.0-next.0e05932b.tgz#6be3648264e4c53db88946b7e7830e983b4f7845"
+  integrity sha512-sjlIirOmnsXrdS1csbcBW2M25UjPzMt50aYwoKbjTsC0u3SJFxXXgmy4ZJwtxdDN90gsBntRT2G/3iT/e7CvNg==
 
 "@eslint/eslintrc@^0.4.3":
   version "0.4.3"


### PR DESCRIPTION
Update to latest glsp-config version to consume https://github.com/eclipse-glsp/glsp/pull/405
(Update eslint-config to display formatting linting issues that get autofixed by prettier as warning)
(This is possible for all formatting linting rules except the "indent" rule. This rule has to be disabled. Prettier uses a dynamic indent size (e.g. spread objects (...) are formatted with two additional spaces, whereas es-lint only supports a static/fixed indent size. This causes unfixable warnings if the rule is activated. Prettier will still format and indent all lines correctly on save.

This means the developer should now get direct feedback in the editor again if there is a formatting issue like using " instead of ', multiple consecutive  empty lines, missing semicolons etc.

Also:
- Align yarn version range with Theia
- Add prettier as default formatter for "javascriptreact" (.jsx files).
- Fix minor formatting inconsistencies