### PR TITLE
#406 Set Theia keyboard dispatch workspace setting to 'keyCode'

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -75,10 +75,8 @@
       "request": "launch",
       "name": "Launch Workflow Browser Frontend",
       "url": "http://localhost:3000",
-      "webRoot": "${workspaceFolder}",
-      "sourceMapPathOverrides": {
-        "./src/*": "${workspaceFolder}/src/*"
-      },
+      "sourceMaps": true,
+      "webRoot": "${workspaceRoot}/examples/browser-app",
       "presentation": {
         "group": "Browser launch configurations",
         "order": 2

--- a/examples/workspace/.theia/settings.json
+++ b/examples/workspace/.theia/settings.json
@@ -1,0 +1,6 @@
+{
+  "files.exclude": {
+    "**/.theia": true
+  },
+  "keyboard.dispatch": "keyCode"
+}


### PR DESCRIPTION
- This setting ensures, that keypresses are interpreted by the 'keyCode' provided by the OS (e.g. if setting is set to 'code', Ctrl+z would not work if a german layout is used instead of the english one)
- Fix Theia launch config 'Launch Workflow Browser Frontend'

Part of https://github.com/eclipse-glsp/glsp/issues/406