### PR TITLE
Store/restore viewport state on Theia close/reopen and editor close/reopen

### DIFF
--- a/packages/theia-integration/src/browser/diagram/glsp-diagram-manager.ts
+++ b/packages/theia-integration/src/browser/diagram/glsp-diagram-manager.ts
@@ -19,6 +19,7 @@ import {
     FrontendApplicationContribution,
     NavigatableWidgetOptions,
     OpenHandler,
+    StorageService,
     WidgetFactory,
     WidgetOpenerOptions
 } from '@theia/core/lib/browser';
@@ -59,6 +60,9 @@ export type TheiaGLSPConnectorProvider = (diagramType: string) => Promise<TheiaG
 export abstract class GLSPDiagramManager extends DiagramManager {
     @inject(EditorPreferences)
     protected readonly editorPreferences: EditorPreferences;
+
+    @inject(StorageService)
+    protected readonly storage: StorageService;
 
     @inject(TheiaOpenerOptionsNavigationService)
     protected readonly diagramNavigationService: TheiaOpenerOptionsNavigationService;
@@ -112,6 +116,7 @@ export abstract class GLSPDiagramManager extends DiagramManager {
                 widgetId,
                 diContainer,
                 this.editorPreferences,
+                this.storage,
                 this.theiaSelectionService,
                 this.diagramConnector
             );


### PR DESCRIPTION
With this PR, we store the viewport state on Theia close (e.g. browser refresh) and restore the state from the application layout.
Optionally (see flag `GLSPDiagramWidget#storeViewportStateOnClose`), we also store the viewport state on editor close and restore it on re-open.

Fixes eclipse-glsp/glsp#475