### PR TITLE
Fix duplicate viewport change on navigation

### DIFF
--- a/packages/theia-integration/src/browser/diagram/glsp-diagram-manager.ts
+++ b/packages/theia-integration/src/browser/diagram/glsp-diagram-manager.ts
@@ -92,6 +92,7 @@ export abstract class GLSPDiagramManager extends DiagramManager {
     }
 
     async doOpen(widget: DiagramWidget, options?: WidgetOpenerOptions): Promise<void> {
+        const widgetWasAttached = widget.isAttached;
         await super.doOpen(widget);
         const navigations = this.diagramNavigationService.determineNavigations(widget.uri.toString(true), options);
         if (navigations.length > 0) {
@@ -100,6 +101,8 @@ export abstract class GLSPDiagramManager extends DiagramManager {
             } else {
                 widget.actionDispatcher.dispatchAll(navigations);
             }
+        } else if (!widgetWasAttached && widget instanceof GLSPDiagramWidget) {
+            widget.restoreViewportDataFromStorageService();
         }
     }
 

--- a/packages/theia-integration/src/browser/diagram/glsp-diagram-widget.ts
+++ b/packages/theia-integration/src/browser/diagram/glsp-diagram-widget.ts
@@ -118,7 +118,6 @@ export class GLSPDiagramWidget extends DiagramWidget implements SaveableSource {
             this.addClipboardListener(this.node, 'paste', e => this.handlePaste(e));
             this.addClipboardListener(this.node, 'cut', e => this.handleCut(e));
         }
-        this.restoreViewportDataFromStorageService();
     }
 
     protected onBeforeDetach(msg: Message): void {
@@ -240,7 +239,7 @@ export class GLSPDiagramWidget extends DiagramWidget implements SaveableSource {
         }
     }
 
-    protected async restoreViewportDataFromStorageService(): Promise<void> {
+    async restoreViewportDataFromStorageService(): Promise<void> {
         if (!this.storeViewportStateOnClose) {
             return;
         }


### PR DESCRIPTION
Thanks for the review of the feature #101! I discovered a small issue with this PR. Here is the fix.

*Issue*

If we directly open a diagram and navigate to an element we now get two viewport changes: one restores the viewport
and one navigates to the navigation target. This can be reproduced by closing the editor on a particular viewport and then using the Theia command `Open example1.wf task "Push"`.

To avoid that, we let the diagram manager decide whether the widget should restore the viewport. Imho this gives more flexibility anyway.

https://github.com/eclipse-glsp/glsp/issues/475