### PR TITLE
Make top border height of palette consistent

### DIFF
--- a/packages/theia-integration/css/tool-palette.css
+++ b/packages/theia-integration/css/tool-palette.css
@@ -37,7 +37,7 @@
 }
 
 .inactive .tool-palette .palette-header {
-    border-top: 2px solid var(--theia-tab-unfocusedInactiveForeground);
+    border-top: 1px solid var(--theia-tab-unfocusedInactiveForeground);
 }
 
 .tool-palette .palette-header .header-icon {


### PR DESCRIPTION
When switching between active and inactive, the height of the border switches between 1px and 2px.
This change makes it consistent to 1px.