### PR TITLE
Remove deprecated shell method

### DIFF
--- a/packages/theia-integration/src/browser/diagram/glsp-diagram-context-key-service.ts
+++ b/packages/theia-integration/src/browser/diagram/glsp-diagram-context-key-service.ts
@@ -57,7 +57,7 @@ export abstract class AbstractGLSPDiagramContextKeyService {
     protected init(): void {
         this.registerContextKeys();
         this.updateContextKeys();
-        this.shell.activeChanged.connect(() => this.updateContextKeys());
+        this.shell.onDidChangeActiveWidget(() => this.updateContextKeys());
     }
 
     protected updateContextKeys(): void {


### PR DESCRIPTION
The shell `activeChanged` emitter is deprecated and in new versions of theia even removed. Thus it is replaced.