### PR TITLE
Fix background of lower corners in tool palette

### DIFF
--- a/packages/theia-integration/css/tool-palette.css
+++ b/packages/theia-integration/css/tool-palette.css
@@ -20,6 +20,10 @@
     width: 210px;
 }
 
+.tool-group {
+    background-color: unset;
+}
+
 .tool-palette .palette-header {
     background: var(--theia-titleBar-activeBackground);
     color: var(--theia-titleBar-activeForeground);


### PR DESCRIPTION
The tool palette has somewhat ugly differently colored pixels in the lower left and right corner as a different background is inherited and shines through because of the rounded corners. With this change, we unset the background to get rid of this effect.

https://github.com/eclipse-glsp/glsp/issues/492