### PR TITLE
#609 Adapt to  client changes

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -39,7 +39,7 @@
     {
       "type": "node",
       "request": "launch",
-      "name": "Launch Workflow Browser Backend (DEBUG)",
+      "name": "Launch Workflow Browser Backend (External GLSP Server)",
       "program": "${workspaceRoot}/examples/browser-app/src-gen/backend/main.js",
       "args": [
         "--hostname=localhost",
@@ -82,6 +82,21 @@
         "order": 2
       },
       "runtimeArgs": ["--incognito"]
+    }
+  ],
+  "compounds": [
+    {
+      "name": "Launch Workflow Browser Backend & Frontend",
+      "configurations": ["Launch Workflow Browser Backend", "Launch Workflow Browser Frontend"],
+      "stopAll": true
+    },
+    {
+      "name": "Launch Workflow Browser Backend & Frontend (External GLSP Server)",
+      "configurations": [
+        "Launch Workflow Browser Backend (External GLSP Server)",
+        "Launch Workflow Browser Frontend"
+      ],
+      "stopAll": true
     }
   ]
 }

--- a/examples/browser-app/package.json
+++ b/examples/browser-app/package.json
@@ -4,20 +4,20 @@
   "version": "0.9.0",
   "dependencies": {
     "@eclipse-glsp-examples/workflow-theia": "0.9.0",
-    "@theia/core": "^1.0.0",
-    "@theia/editor": "^1.0.0",
-    "@theia/filesystem": "^1.0.0",
-    "@theia/markers": "^1.0.0",
-    "@theia/messages": "^1.0.0",
-    "@theia/monaco": "^1.0.0",
-    "@theia/navigator": "^1.0.0",
-    "@theia/preferences": "^1.0.0",
-    "@theia/process": "^1.0.0",
-    "@theia/terminal": "^1.0.0",
-    "@theia/workspace": "^1.0.0"
+    "@theia/core": "^1.24.0",
+    "@theia/editor": "^1.24.0",
+    "@theia/filesystem": "^1.24.0",
+    "@theia/markers": "^1.24.0",
+    "@theia/messages": "^1.24.0",
+    "@theia/monaco": "^1.24.0",
+    "@theia/navigator": "^1.24.0",
+    "@theia/preferences": "^1.24.0",
+    "@theia/process": "^1.24.0",
+    "@theia/terminal": "^1.24.0",
+    "@theia/workspace": "^1.24.0"
   },
   "devDependencies": {
-    "@theia/cli": "^1.0.0"
+    "@theia/cli": "^1.24.0"
   },
   "scripts": {
     "prepare": "yarn build",

--- a/examples/workflow-theia/.eslintrc.js
+++ b/examples/workflow-theia/.eslintrc.js
@@ -4,5 +4,19 @@ module.exports = {
     parserOptions: {
         tsconfigRootDir: __dirname,
         project: 'tsconfig.json'
+    },
+    rules: {
+        'no-restricted-imports': [
+            'warn',
+            {
+                name: 'sprotty',
+                message: "The sprotty default exports are customized and reexported by GLSP. Please use '@eclipse-glsp/client' instead"
+            },
+            {
+                name: 'sprotty-protocol',
+                message:
+                    "The sprotty-protocol default exports are customized and reexported by GLSP. Please use '@eclipse-glsp/client' instead"
+            }
+        ]
     }
 };

--- a/packages/theia-integration/package.json
+++ b/packages/theia-integration/package.json
@@ -40,7 +40,7 @@
   ],
   "dependencies": {
     "@eclipse-glsp/client": "next",
-    "@theia/messages": "^1.0.0",
+    "@theia/messages": "^1.24.0",
     "sprotty-theia": "next"
   },
   "scripts": {

--- a/packages/theia-integration/src/browser/diagram/glsp-diagram-widget.ts
+++ b/packages/theia-integration/src/browser/diagram/glsp-diagram-widget.ts
@@ -72,8 +72,8 @@ export class GLSPDiagramWidget extends DiagramWidget implements SaveableSource {
     }
 
     protected updateSaveable(): void {
-        this.saveable.autoSave = this.editorPreferences['editor.autoSave'];
-        this.saveable.autoSaveDelay = this.editorPreferences['editor.autoSaveDelay'];
+        this.saveable.autoSave = this.editorPreferences['files.autoSave'];
+        this.saveable.autoSaveDelay = this.editorPreferences['files.autoSaveDelay'];
     }
 
     protected override initializeSprotty(): void {
@@ -296,8 +296,10 @@ export function getDiagramWidget(widget: Widget): GLSPDiagramWidget | undefined 
     return undefined;
 }
 
+type AutoSaveType = 'off' | 'afterDelay' | 'onFocusChange' | 'onWindowChange';
+
 export class SaveableGLSPModelSource implements Saveable, Disposable {
-    isAutoSave: 'on' | 'off' = 'on';
+    protected _autoSave: AutoSaveType = 'off';
     autoSaveDelay = 500;
 
     private autoSaveJobs = new DisposableCollection();
@@ -331,8 +333,8 @@ export class SaveableGLSPModelSource implements Saveable, Disposable {
         this.scheduleAutoSave();
     }
 
-    set autoSave(isAutoSave: 'on' | 'off') {
-        this.isAutoSave = isAutoSave;
+    set autoSave(autoSave: AutoSaveType) {
+        this._autoSave = autoSave;
         if (this.shouldAutoSave) {
             this.scheduleAutoSave();
         } else {
@@ -340,8 +342,8 @@ export class SaveableGLSPModelSource implements Saveable, Disposable {
         }
     }
 
-    get autoSave(): 'on' | 'off' {
-        return this.isAutoSave;
+    get autoSave(): AutoSaveType {
+        return this._autoSave;
     }
 
     protected scheduleAutoSave(): void {
@@ -360,7 +362,7 @@ export class SaveableGLSPModelSource implements Saveable, Disposable {
     }
 
     protected get shouldAutoSave(): boolean {
-        return this.dirty && this.autoSave === 'on';
+        return this.dirty && this.autoSave !== 'off';
     }
 
     dispose(): void {

--- a/packages/theia-integration/src/browser/diagram/glsp-diagram-widget.ts
+++ b/packages/theia-integration/src/browser/diagram/glsp-diagram-widget.ts
@@ -365,6 +365,16 @@ export class SaveableGLSPModelSource implements Saveable, Disposable {
         return this.dirty && this.autoSave !== 'off';
     }
 
+    // Needs to be implemented to pass the type check of `WorkspaceFrontendContribution.canBeSaved`.
+    async revert(options?: Saveable.RevertOptions): Promise<void> {
+        console.warn('GLSP only supports server-side saving. The `revert` implementation is no-op and has no effect.');
+    }
+
+    // Needs to be implemented to pass the type check of `WorkspaceFrontendContribution.canBeSaved`.
+    createSnapshot(): object {
+        throw new Error('GLSP only supports server-side saving. `createSnapshot` should never be invoked');
+    }
+
     dispose(): void {
         this.autoSaveJobs.dispose();
         this.dirtyChangedEmitter.dispose();

--- a/packages/theia-integration/src/browser/diagram/glsp-layout-commands.ts
+++ b/packages/theia-integration/src/browser/diagram/glsp-layout-commands.ts
@@ -15,14 +15,11 @@
  ********************************************************************************/
 import {
     AlignElementsAction,
-    AlignElementsCommand,
     Alignment,
-    BoundsAwareModelElement,
-    Reduce,
+    ReduceFunctionType,
     ResizeDimension,
     ResizeElementsAction,
-    ResizeElementsCommand,
-    Select
+    SelectFunctionType
 } from '@eclipse-glsp/client';
 import { CommandContribution, CommandRegistry, MenuContribution, MenuModelRegistry, MenuPath } from '@theia/core';
 import { ApplicationShell, KeybindingContribution, KeybindingRegistry } from '@theia/core/lib/browser';
@@ -37,76 +34,76 @@ export function registerDiagramLayoutCommands(bind: interfaces.Bind): void {
 }
 
 export namespace GLSPLayoutCommands {
-    export const RESIZE_WIDTH_MIN = 'glsp:' + ResizeElementsCommand.KIND + ':width:min';
+    export const RESIZE_WIDTH_MIN = 'glsp:' + ResizeElementsAction.KIND + ':width:min';
     export const RESIZE_WIDTH_MIN_LABEL = 'Minimal Width';
-    export const RESIZE_WIDTH_MAX = 'glsp:' + ResizeElementsCommand.KIND + ':width:max';
+    export const RESIZE_WIDTH_MAX = 'glsp:' + ResizeElementsAction.KIND + ':width:max';
     export const RESIZE_WIDTH_MAX_LABEL = 'Maximal Width';
-    export const RESIZE_WIDTH_AVG = 'glsp:' + ResizeElementsCommand.KIND + ':width:avg';
+    export const RESIZE_WIDTH_AVG = 'glsp:' + ResizeElementsAction.KIND + ':width:avg';
     export const RESIZE_WIDTH_AVG_LABEL = 'Average Width';
-    export const RESIZE_WIDTH_FIRST = 'glsp:' + ResizeElementsCommand.KIND + ':width:first';
+    export const RESIZE_WIDTH_FIRST = 'glsp:' + ResizeElementsAction.KIND + ':width:first';
     export const RESIZE_WIDTH_FIRST_LABEL = 'Width of First Selected Element';
-    export const RESIZE_WIDTH_LAST = 'glsp:' + ResizeElementsCommand.KIND + ':width:last';
+    export const RESIZE_WIDTH_LAST = 'glsp:' + ResizeElementsAction.KIND + ':width:last';
     export const RESIZE_WIDTH_LAST_LABEL = 'Width of Last Selected Element';
 
-    export const RESIZE_HEIGHT_MIN = 'glsp:' + ResizeElementsCommand.KIND + ':height:min';
+    export const RESIZE_HEIGHT_MIN = 'glsp:' + ResizeElementsAction.KIND + ':height:min';
     export const RESIZE_HEIGHT_MIN_LABEL = 'Minimal Height';
-    export const RESIZE_HEIGHT_MAX = 'glsp:' + ResizeElementsCommand.KIND + ':height:max';
+    export const RESIZE_HEIGHT_MAX = 'glsp:' + ResizeElementsAction.KIND + ':height:max';
     export const RESIZE_HEIGHT_MAX_LABEL = 'Maximal Height';
-    export const RESIZE_HEIGHT_AVG = 'glsp:' + ResizeElementsCommand.KIND + ':height:avg';
+    export const RESIZE_HEIGHT_AVG = 'glsp:' + ResizeElementsAction.KIND + ':height:avg';
     export const RESIZE_HEIGHT_AVG_LABEL = 'Average Height';
-    export const RESIZE_HEIGHT_FIRST = 'glsp:' + ResizeElementsCommand.KIND + ':height:first';
+    export const RESIZE_HEIGHT_FIRST = 'glsp:' + ResizeElementsAction.KIND + ':height:first';
     export const RESIZE_HEIGHT_FIRST_LABEL = 'Height of First Selected Element';
-    export const RESIZE_HEIGHT_LAST = 'glsp:' + ResizeElementsCommand.KIND + ':height:last';
+    export const RESIZE_HEIGHT_LAST = 'glsp:' + ResizeElementsAction.KIND + ':height:last';
     export const RESIZE_HEIGHT_LAST_LABEL = 'Height of Last Selected Element';
 
-    export const RESIZE_WIDTH_AND_HEIGHT_MIN = 'glsp:' + ResizeElementsCommand.KIND + ':width_and_height:min';
+    export const RESIZE_WIDTH_AND_HEIGHT_MIN = 'glsp:' + ResizeElementsAction.KIND + ':width_and_height:min';
     export const RESIZE_WIDTH_AND_HEIGHT_MIN_LBL = 'Minimal Width and Height';
-    export const RESIZE_WIDTH_AND_HEIGHT_MAX = 'glsp:' + ResizeElementsCommand.KIND + ':width_and_height:max';
+    export const RESIZE_WIDTH_AND_HEIGHT_MAX = 'glsp:' + ResizeElementsAction.KIND + ':width_and_height:max';
     export const RESIZE_WIDTH_AND_HEIGHT_MAX_LBL = 'Maximal Width and Height';
-    export const RESIZE_WIDTH_AND_HEIGHT_AVG = 'glsp:' + ResizeElementsCommand.KIND + ':width_and_height:avg';
+    export const RESIZE_WIDTH_AND_HEIGHT_AVG = 'glsp:' + ResizeElementsAction.KIND + ':width_and_height:avg';
     export const RESIZE_WIDTH_AND_HEIGHT_AVG_LBL = 'Average Width and Height';
-    export const RESIZE_WIDTH_AND_HEIGHT_FIRST = 'glsp:' + ResizeElementsCommand.KIND + ':width_and_height:first';
+    export const RESIZE_WIDTH_AND_HEIGHT_FIRST = 'glsp:' + ResizeElementsAction.KIND + ':width_and_height:first';
     export const RESIZE_WIDTH_AND_HEIGHT_FIRST_LBL = 'Width and Height of First Selected Element';
-    export const RESIZE_WIDTH_AND_HEIGHT_LAST = 'glsp:' + ResizeElementsCommand.KIND + ':width_and_height:last';
+    export const RESIZE_WIDTH_AND_HEIGHT_LAST = 'glsp:' + ResizeElementsAction.KIND + ':width_and_height:last';
     export const RESIZE_WIDTH_AND_HEIGHT_LAST_LBL = 'Width and Height of Last Selected Element';
 
-    export const ALIGN_LEFT = 'glsp:' + AlignElementsCommand.KIND + ':left';
+    export const ALIGN_LEFT = 'glsp:' + AlignElementsAction.KIND + ':left';
     export const ALIGN_LEFT_LABEL = 'Left';
-    export const ALIGN_CENTER = 'glsp:' + AlignElementsCommand.KIND + ':center';
+    export const ALIGN_CENTER = 'glsp:' + AlignElementsAction.KIND + ':center';
     export const ALIGN_CENTER_LABEL = 'Center';
-    export const ALIGN_RIGHT = 'glsp:' + AlignElementsCommand.KIND + ':right';
+    export const ALIGN_RIGHT = 'glsp:' + AlignElementsAction.KIND + ':right';
     export const ALIGN_RIGHT_LABEL = 'Right';
-    export const ALIGN_TOP = 'glsp:' + AlignElementsCommand.KIND + ':top';
+    export const ALIGN_TOP = 'glsp:' + AlignElementsAction.KIND + ':top';
     export const ALIGN_TOP_LABEL = 'Top';
-    export const ALIGN_MIDDLE = 'glsp:' + AlignElementsCommand.KIND + ':middle';
+    export const ALIGN_MIDDLE = 'glsp:' + AlignElementsAction.KIND + ':middle';
     export const ALIGN_MIDDLE_LABEL = 'Middle';
-    export const ALIGN_BOTTOM = 'glsp:' + AlignElementsCommand.KIND + ':bottom';
+    export const ALIGN_BOTTOM = 'glsp:' + AlignElementsAction.KIND + ':bottom';
     export const ALIGN_BOTTOM_LABEL = 'Bottom';
 
-    export const ALIGN_LEFT_FIRST = 'glsp:' + AlignElementsCommand.KIND + ':left:first';
+    export const ALIGN_LEFT_FIRST = 'glsp:' + AlignElementsAction.KIND + ':left:first';
     export const ALIGN_LEFT_FIRST_LABEL = 'Left of First Selected Element';
-    export const ALIGN_CENTER_FIRST = 'glsp:' + AlignElementsCommand.KIND + ':center:first';
+    export const ALIGN_CENTER_FIRST = 'glsp:' + AlignElementsAction.KIND + ':center:first';
     export const ALIGN_CENTER_FIRST_LABEL = 'Center of First Selected Element';
-    export const ALIGN_RIGHT_FIRST = 'glsp:' + AlignElementsCommand.KIND + ':right:first';
+    export const ALIGN_RIGHT_FIRST = 'glsp:' + AlignElementsAction.KIND + ':right:first';
     export const ALIGN_RIGHT_FIRST_LABEL = 'Right of First Selected Element';
-    export const ALIGN_TOP_FIRST = 'glsp:' + AlignElementsCommand.KIND + ':top:first';
+    export const ALIGN_TOP_FIRST = 'glsp:' + AlignElementsAction.KIND + ':top:first';
     export const ALIGN_TOP_FIRST_LABEL = 'Top of First Selected Element';
-    export const ALIGN_MIDDLE_FIRST = 'glsp:' + AlignElementsCommand.KIND + ':middle:first';
+    export const ALIGN_MIDDLE_FIRST = 'glsp:' + AlignElementsAction.KIND + ':middle:first';
     export const ALIGN_MIDDLE_FIRST_LABEL = 'Middle of First Selected Element';
-    export const ALIGN_BOTTOM_FIRST = 'glsp:' + AlignElementsCommand.KIND + ':bottom:first';
+    export const ALIGN_BOTTOM_FIRST = 'glsp:' + AlignElementsAction.KIND + ':bottom:first';
     export const ALIGN_BOTTOM_FIRST_LABEL = 'Bottom of First Selected Element';
 
-    export const ALIGN_LEFT_LAST = 'glsp:' + AlignElementsCommand.KIND + ':left:last';
+    export const ALIGN_LEFT_LAST = 'glsp:' + AlignElementsAction.KIND + ':left:last';
     export const ALIGN_LEFT_LAST_LABEL = 'Left of Last Selected Element';
-    export const ALIGN_CENTER_LAST = 'glsp:' + AlignElementsCommand.KIND + ':center:last';
+    export const ALIGN_CENTER_LAST = 'glsp:' + AlignElementsAction.KIND + ':center:last';
     export const ALIGN_CENTER_LAST_LABEL = 'Center of Last Selected Element';
-    export const ALIGN_RIGHT_LAST = 'glsp:' + AlignElementsCommand.KIND + ':right:last';
+    export const ALIGN_RIGHT_LAST = 'glsp:' + AlignElementsAction.KIND + ':right:last';
     export const ALIGN_RIGHT_LAST_LABEL = 'Right of Last Selected Element';
-    export const ALIGN_TOP_LAST = 'glsp:' + AlignElementsCommand.KIND + ':top:last';
+    export const ALIGN_TOP_LAST = 'glsp:' + AlignElementsAction.KIND + ':top:last';
     export const ALIGN_TOP_LAST_LABEL = 'Top of Last Selected Element';
-    export const ALIGN_MIDDLE_LAST = 'glsp:' + AlignElementsCommand.KIND + ':middle:last';
+    export const ALIGN_MIDDLE_LAST = 'glsp:' + AlignElementsAction.KIND + ':middle:last';
     export const ALIGN_MIDDLE_LAST_LABEL = 'Middle of Last Selected Element';
-    export const ALIGN_BOTTOM_LAST = 'glsp:' + AlignElementsCommand.KIND + ':bottom:last';
+    export const ALIGN_BOTTOM_LAST = 'glsp:' + AlignElementsAction.KIND + ':bottom:last';
     export const ALIGN_BOTTOM_LAST_LABEL = 'Bottom of Last Selected Element';
 }
 
@@ -279,7 +276,7 @@ export class GLSPLayoutCommandContribution implements CommandContribution {
         id: string,
         label: string,
         dimension: ResizeDimension,
-        reductionFunction: (...values: number[]) => number
+        reduceFunction: ReduceFunctionType
     ): void {
         registry.registerCommand(
             {
@@ -288,19 +285,13 @@ export class GLSPLayoutCommandContribution implements CommandContribution {
                 label: 'Resize to ' + label
             },
             new GLSPCommandHandler(this.shell, {
-                actions: () => [ResizeElementsAction.create({ dimension, reductionFunction })],
+                actions: () => [ResizeElementsAction.create({ dimension, reduceFunction })],
                 isEnabled: context => !context.isReadonly && context.get().selectedElementIds.length > 1
             })
         );
     }
 
-    registerAlign(
-        registry: CommandRegistry,
-        id: string,
-        label: string,
-        alignment: Alignment,
-        selectionFunction: (elements: BoundsAwareModelElement[]) => BoundsAwareModelElement[]
-    ): void {
+    registerAlign(registry: CommandRegistry, id: string, label: string, alignment: Alignment, selectionFunction: SelectFunctionType): void {
         registry.registerCommand(
             {
                 id: id,
@@ -320,35 +311,35 @@ export class GLSPLayoutCommandContribution implements CommandContribution {
             GLSPLayoutCommands.RESIZE_WIDTH_MIN,
             GLSPLayoutCommands.RESIZE_WIDTH_MIN_LABEL,
             ResizeDimension.Width,
-            Reduce.min
+            'min'
         );
         this.registerResize(
             reg,
             GLSPLayoutCommands.RESIZE_WIDTH_MAX,
             GLSPLayoutCommands.RESIZE_WIDTH_MAX_LABEL,
             ResizeDimension.Width,
-            Reduce.max
+            'max'
         );
         this.registerResize(
             reg,
             GLSPLayoutCommands.RESIZE_WIDTH_AVG,
             GLSPLayoutCommands.RESIZE_WIDTH_AVG_LABEL,
             ResizeDimension.Width,
-            Reduce.avg
+            'avg'
         );
         this.registerResize(
             reg,
             GLSPLayoutCommands.RESIZE_WIDTH_FIRST,
             GLSPLayoutCommands.RESIZE_WIDTH_FIRST_LABEL,
             ResizeDimension.Width,
-            Reduce.first
+            'first'
         );
         this.registerResize(
             reg,
             GLSPLayoutCommands.RESIZE_WIDTH_LAST,
             GLSPLayoutCommands.RESIZE_WIDTH_LAST_LABEL,
             ResizeDimension.Width,
-            Reduce.last
+            'last'
         );
 
         this.registerResize(
@@ -356,35 +347,35 @@ export class GLSPLayoutCommandContribution implements CommandContribution {
             GLSPLayoutCommands.RESIZE_HEIGHT_MIN,
             GLSPLayoutCommands.RESIZE_HEIGHT_MIN_LABEL,
             ResizeDimension.Height,
-            Reduce.min
+            'min'
         );
         this.registerResize(
             reg,
             GLSPLayoutCommands.RESIZE_HEIGHT_MAX,
             GLSPLayoutCommands.RESIZE_HEIGHT_MAX_LABEL,
             ResizeDimension.Height,
-            Reduce.max
+            'max'
         );
         this.registerResize(
             reg,
             GLSPLayoutCommands.RESIZE_HEIGHT_AVG,
             GLSPLayoutCommands.RESIZE_HEIGHT_AVG_LABEL,
             ResizeDimension.Height,
-            Reduce.avg
+            'avg'
         );
         this.registerResize(
             reg,
             GLSPLayoutCommands.RESIZE_HEIGHT_FIRST,
             GLSPLayoutCommands.RESIZE_HEIGHT_FIRST_LABEL,
             ResizeDimension.Height,
-            Reduce.first
+            'first'
         );
         this.registerResize(
             reg,
             GLSPLayoutCommands.RESIZE_HEIGHT_LAST,
             GLSPLayoutCommands.RESIZE_HEIGHT_LAST_LABEL,
             ResizeDimension.Height,
-            Reduce.last
+            'last'
         );
 
         this.registerResize(
@@ -392,111 +383,75 @@ export class GLSPLayoutCommandContribution implements CommandContribution {
             GLSPLayoutCommands.RESIZE_WIDTH_AND_HEIGHT_MIN,
             GLSPLayoutCommands.RESIZE_WIDTH_AND_HEIGHT_MIN_LBL,
             ResizeDimension.Width_And_Height,
-            Reduce.min
+            'min'
         );
         this.registerResize(
             reg,
             GLSPLayoutCommands.RESIZE_WIDTH_AND_HEIGHT_MAX,
             GLSPLayoutCommands.RESIZE_WIDTH_AND_HEIGHT_MAX_LBL,
             ResizeDimension.Width_And_Height,
-            Reduce.max
+            'max'
         );
         this.registerResize(
             reg,
             GLSPLayoutCommands.RESIZE_WIDTH_AND_HEIGHT_AVG,
             GLSPLayoutCommands.RESIZE_WIDTH_AND_HEIGHT_AVG_LBL,
             ResizeDimension.Width_And_Height,
-            Reduce.avg
+            'avg'
         );
         this.registerResize(
             reg,
             GLSPLayoutCommands.RESIZE_WIDTH_AND_HEIGHT_FIRST,
             GLSPLayoutCommands.RESIZE_WIDTH_AND_HEIGHT_FIRST_LBL,
             ResizeDimension.Width_And_Height,
-            Reduce.first
+            'first'
         );
         this.registerResize(
             reg,
             GLSPLayoutCommands.RESIZE_WIDTH_AND_HEIGHT_LAST,
             GLSPLayoutCommands.RESIZE_WIDTH_AND_HEIGHT_LAST_LBL,
             ResizeDimension.Width_And_Height,
-            Reduce.last
+            'last'
         );
 
-        this.registerAlign(reg, GLSPLayoutCommands.ALIGN_LEFT, GLSPLayoutCommands.ALIGN_LEFT_LABEL, Alignment.Left, Select.all);
-        this.registerAlign(reg, GLSPLayoutCommands.ALIGN_CENTER, GLSPLayoutCommands.ALIGN_CENTER_LABEL, Alignment.Center, Select.all);
-        this.registerAlign(reg, GLSPLayoutCommands.ALIGN_RIGHT, GLSPLayoutCommands.ALIGN_RIGHT_LABEL, Alignment.Right, Select.all);
-        this.registerAlign(reg, GLSPLayoutCommands.ALIGN_TOP, GLSPLayoutCommands.ALIGN_TOP_LABEL, Alignment.Top, Select.all);
-        this.registerAlign(reg, GLSPLayoutCommands.ALIGN_MIDDLE, GLSPLayoutCommands.ALIGN_MIDDLE_LABEL, Alignment.Middle, Select.all);
-        this.registerAlign(reg, GLSPLayoutCommands.ALIGN_BOTTOM, GLSPLayoutCommands.ALIGN_BOTTOM_LABEL, Alignment.Bottom, Select.all);
+        this.registerAlign(reg, GLSPLayoutCommands.ALIGN_LEFT, GLSPLayoutCommands.ALIGN_LEFT_LABEL, Alignment.Left, 'all');
+        this.registerAlign(reg, GLSPLayoutCommands.ALIGN_CENTER, GLSPLayoutCommands.ALIGN_CENTER_LABEL, Alignment.Center, 'all');
+        this.registerAlign(reg, GLSPLayoutCommands.ALIGN_RIGHT, GLSPLayoutCommands.ALIGN_RIGHT_LABEL, Alignment.Right, 'all');
+        this.registerAlign(reg, GLSPLayoutCommands.ALIGN_TOP, GLSPLayoutCommands.ALIGN_TOP_LABEL, Alignment.Top, 'all');
+        this.registerAlign(reg, GLSPLayoutCommands.ALIGN_MIDDLE, GLSPLayoutCommands.ALIGN_MIDDLE_LABEL, Alignment.Middle, 'all');
+        this.registerAlign(reg, GLSPLayoutCommands.ALIGN_BOTTOM, GLSPLayoutCommands.ALIGN_BOTTOM_LABEL, Alignment.Bottom, 'all');
 
-        this.registerAlign(
-            reg,
-            GLSPLayoutCommands.ALIGN_LEFT_FIRST,
-            GLSPLayoutCommands.ALIGN_LEFT_FIRST_LABEL,
-            Alignment.Left,
-            Select.first
-        );
+        this.registerAlign(reg, GLSPLayoutCommands.ALIGN_LEFT_FIRST, GLSPLayoutCommands.ALIGN_LEFT_FIRST_LABEL, Alignment.Left, 'first');
         this.registerAlign(
             reg,
             GLSPLayoutCommands.ALIGN_CENTER_FIRST,
             GLSPLayoutCommands.ALIGN_CENTER_FIRST_LABEL,
             Alignment.Center,
-            Select.first
+            'first'
         );
-        this.registerAlign(
-            reg,
-            GLSPLayoutCommands.ALIGN_RIGHT_FIRST,
-            GLSPLayoutCommands.ALIGN_RIGHT_FIRST_LABEL,
-            Alignment.Right,
-            Select.first
-        );
-        this.registerAlign(reg, GLSPLayoutCommands.ALIGN_TOP_FIRST, GLSPLayoutCommands.ALIGN_TOP_FIRST_LABEL, Alignment.Top, Select.first);
+        this.registerAlign(reg, GLSPLayoutCommands.ALIGN_RIGHT_FIRST, GLSPLayoutCommands.ALIGN_RIGHT_FIRST_LABEL, Alignment.Right, 'first');
+        this.registerAlign(reg, GLSPLayoutCommands.ALIGN_TOP_FIRST, GLSPLayoutCommands.ALIGN_TOP_FIRST_LABEL, Alignment.Top, 'first');
         this.registerAlign(
             reg,
             GLSPLayoutCommands.ALIGN_MIDDLE_FIRST,
             GLSPLayoutCommands.ALIGN_MIDDLE_FIRST_LABEL,
             Alignment.Middle,
-            Select.first
+            'first'
         );
         this.registerAlign(
             reg,
             GLSPLayoutCommands.ALIGN_BOTTOM_FIRST,
             GLSPLayoutCommands.ALIGN_BOTTOM_FIRST_LABEL,
             Alignment.Bottom,
-            Select.first
+            'first'
         );
 
-        this.registerAlign(reg, GLSPLayoutCommands.ALIGN_LEFT_LAST, GLSPLayoutCommands.ALIGN_LEFT_LAST_LABEL, Alignment.Left, Select.last);
-        this.registerAlign(
-            reg,
-            GLSPLayoutCommands.ALIGN_CENTER_LAST,
-            GLSPLayoutCommands.ALIGN_CENTER_LAST_LABEL,
-            Alignment.Center,
-            Select.last
-        );
-        this.registerAlign(
-            reg,
-            GLSPLayoutCommands.ALIGN_RIGHT_LAST,
-            GLSPLayoutCommands.ALIGN_RIGHT_LAST_LABEL,
-            Alignment.Right,
-            Select.last
-        );
-        this.registerAlign(reg, GLSPLayoutCommands.ALIGN_TOP_LAST, GLSPLayoutCommands.ALIGN_TOP_LAST_LABEL, Alignment.Top, Select.last);
-        this.registerAlign(
-            reg,
-            GLSPLayoutCommands.ALIGN_MIDDLE_LAST,
-            GLSPLayoutCommands.ALIGN_MIDDLE_LAST_LABEL,
-            Alignment.Middle,
-            Select.last
-        );
-        this.registerAlign(
-            reg,
-            GLSPLayoutCommands.ALIGN_BOTTOM_LAST,
-            GLSPLayoutCommands.ALIGN_BOTTOM_LAST_LABEL,
-            Alignment.Bottom,
-            Select.last
-        );
+        this.registerAlign(reg, GLSPLayoutCommands.ALIGN_LEFT_LAST, GLSPLayoutCommands.ALIGN_LEFT_LAST_LABEL, Alignment.Left, 'last');
+        this.registerAlign(reg, GLSPLayoutCommands.ALIGN_CENTER_LAST, GLSPLayoutCommands.ALIGN_CENTER_LAST_LABEL, Alignment.Center, 'last');
+        this.registerAlign(reg, GLSPLayoutCommands.ALIGN_RIGHT_LAST, GLSPLayoutCommands.ALIGN_RIGHT_LAST_LABEL, Alignment.Right, 'last');
+        this.registerAlign(reg, GLSPLayoutCommands.ALIGN_TOP_LAST, GLSPLayoutCommands.ALIGN_TOP_LAST_LABEL, Alignment.Top, 'last');
+        this.registerAlign(reg, GLSPLayoutCommands.ALIGN_MIDDLE_LAST, GLSPLayoutCommands.ALIGN_MIDDLE_LAST_LABEL, Alignment.Middle, 'last');
+        this.registerAlign(reg, GLSPLayoutCommands.ALIGN_BOTTOM_LAST, GLSPLayoutCommands.ALIGN_BOTTOM_LAST_LABEL, Alignment.Bottom, 'last');
     }
 }
 

--- a/packages/theia-integration/src/browser/diagram/glsp-theia-diagram-server.ts
+++ b/packages/theia-integration/src/browser/diagram/glsp-theia-diagram-server.ts
@@ -42,7 +42,7 @@ export class GLSPTheiaDiagramServer extends TheiaDiagramServer implements DirtyS
         registry.register(SetDirtyStateAction.KIND, this);
     }
 
-    public getSourceURI(): string {
+    public get sourceURI(): string {
         return this.sourceUri;
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -917,19 +917,19 @@
   integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==
 
 "@eclipse-glsp-examples/workflow-glsp@next":
-  version "0.10.0-next.385713d.170"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp-examples/workflow-glsp/-/workflow-glsp-0.10.0-next.385713d.170.tgz#454b4505dc2b0968bb88616aa15551002ae86884"
-  integrity sha512-w7aByoDnfeO8YHL3AuHSI2dnXElGD1HH102ojTJ+sLBk61Ada/LrSF7LlhHMEnKI0riLai3YlDweZKr2f0B0OQ==
+  version "0.10.0-next.4fb6ef6.171"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp-examples/workflow-glsp/-/workflow-glsp-0.10.0-next.4fb6ef6.171.tgz#495f669ec435a5e2e199a67cfd244aed7ad0da72"
+  integrity sha512-DSbEBYKzBCBRLs5zu5N4G7MPw4cxktzAYAqsZ9UwOttSWjy9aRWaa6TtVY2k+KwaRs10EprMbIhZcrLkjnYIaA==
   dependencies:
-    "@eclipse-glsp/client" "0.10.0-next.385713d.170+385713d"
+    "@eclipse-glsp/client" "0.10.0-next.4fb6ef6.171+4fb6ef6"
     balloon-css "^0.5.0"
 
-"@eclipse-glsp/client@0.10.0-next.385713d.170+385713d", "@eclipse-glsp/client@next":
-  version "0.10.0-next.385713d.170"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp/client/-/client-0.10.0-next.385713d.170.tgz#bd9b7a987c6263cce6c87cedd22341622f1a2d38"
-  integrity sha512-iZFLN0lIRDNTdtBToLXv0rkA5jBvVuLOKmneORnLant0fMbJH6LN7WisnpItjnyI6aObIA13Mt6BJp+MD29H/A==
+"@eclipse-glsp/client@0.10.0-next.4fb6ef6.171+4fb6ef6", "@eclipse-glsp/client@next":
+  version "0.10.0-next.4fb6ef6.171"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp/client/-/client-0.10.0-next.4fb6ef6.171.tgz#0338ec9f6d478270b1e5e9a87d73f97efb81656b"
+  integrity sha512-i+oZsnjkPkVSt+NnsH+BRG3d4/jAHD0dpsX9oOajbspQUkc2p/HogtJSHV1H1umiyalHkpBGgPkSHECR8kAsYw==
   dependencies:
-    "@eclipse-glsp/protocol" "0.10.0-next.385713d.170+385713d"
+    "@eclipse-glsp/protocol" "0.10.0-next.4fb6ef6.171+4fb6ef6"
     autocompleter "5.1.0"
     sprotty next
 
@@ -979,10 +979,10 @@
   resolved "https://registry.yarnpkg.com/@eclipse-glsp/prettier-config/-/prettier-config-0.10.0-next.b7bb985.103.tgz#2ad708ca691e8fe228b98e0ce673dbba43a2ef8c"
   integrity sha512-GrIHVf41ZYfoHIs97JXukUAmTS6IHQ4n1MnIJcNILJ38lLoFb254QYWdpLybbtu8xmXMdqPOHlrJE1J6TrB5Ow==
 
-"@eclipse-glsp/protocol@0.10.0-next.385713d.170+385713d":
-  version "0.10.0-next.385713d.170"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp/protocol/-/protocol-0.10.0-next.385713d.170.tgz#07adeb29c05fb3a163959e390f7a28e84a7d5468"
-  integrity sha512-40ztBb5zna2b3BQDmdwRHp7a7JmHRDInoRwxG5Ub/KgSd1qiqv0wSXqhdYIBu4BQvzhS473zN/x/DBJVHYuyOA==
+"@eclipse-glsp/protocol@0.10.0-next.4fb6ef6.171+4fb6ef6":
+  version "0.10.0-next.4fb6ef6.171"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp/protocol/-/protocol-0.10.0-next.4fb6ef6.171.tgz#27717e9d2251d2af26855a840ad7e262072688de"
+  integrity sha512-0gR+tOkH3C6bTT+XDor6UbVzDUrrrkEc44A1MNREjXkX2Ctmaj6i84ZMCjPl6FClBrrYyykyGCp9KKwQGHvACw==
   dependencies:
     sprotty-protocol next
     uuid "7.0.3"
@@ -2748,9 +2748,9 @@
   integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
 
 "@types/prop-types@*":
-  version "15.7.4"
-  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.4.tgz#fcf7205c25dff795ee79af1e30da2c9790808f11"
-  integrity sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==
+  version "15.7.5"
+  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.5.tgz#5f19d2b85a98e9558036f6a3cacc8819420f05cf"
+  integrity sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==
 
 "@types/puppeteer@^2.0.0":
   version "2.1.7"
@@ -2777,26 +2777,26 @@
     "@types/react" "^16"
 
 "@types/react-virtualized@^9.18.3":
-  version "9.21.20"
-  resolved "https://registry.yarnpkg.com/@types/react-virtualized/-/react-virtualized-9.21.20.tgz#756c78b5512a2a1804fdaf749a5f5cff3d805e5b"
-  integrity sha512-i8nZf1LpuX5rG4DZLaPGayIQwjxsZwmst5VdNhEznDTENel9p3A735AdRRp2iueFOyOuWBmaEaDxg8AD3GHilA==
+  version "9.21.21"
+  resolved "https://registry.yarnpkg.com/@types/react-virtualized/-/react-virtualized-9.21.21.tgz#65c96f25314f0fb3d40536929dc78112753b49e1"
+  integrity sha512-Exx6I7p4Qn+BBA1SRyj/UwQlZ0I0Pq7g7uhAp0QQ4JWzZunqEqNBGTmCmMmS/3N9wFgAGWuBD16ap7k8Y14VPA==
   dependencies:
     "@types/prop-types" "*"
-    "@types/react" "*"
-
-"@types/react@*":
-  version "17.0.43"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.43.tgz#4adc142887dd4a2601ce730bc56c3436fdb07a55"
-  integrity sha512-8Q+LNpdxf057brvPu1lMtC5Vn7J119xrP1aq4qiaefNioQUYANF/CYeK4NsKorSZyUGJ66g0IM+4bbjwx45o2A==
-  dependencies:
-    "@types/prop-types" "*"
-    "@types/scheduler" "*"
-    csstype "^3.0.2"
+    "@types/react" "^17"
 
 "@types/react@^16", "@types/react@^16.8.0":
   version "16.14.24"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.14.24.tgz#f2c5e9fa78f83f769884b83defcf7924b9eb5c82"
   integrity sha512-e7U2WC8XQP/xfR7bwhOhNFZKPTfW1ph+MiqtudKb8tSV8RyCsovQx2sNVtKoOryjxFKpHPPC/yNiGfdeVM5Gyw==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "*"
+    csstype "^3.0.2"
+
+"@types/react@^17":
+  version "17.0.44"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.44.tgz#c3714bd34dd551ab20b8015d9d0dbec812a51ec7"
+  integrity sha512-Ye0nlw09GeMp2Suh8qoOv0odfgCoowfM/9MG6WeRD60Gq9wS90bdkdRtYbRkNhXOpG4H+YXGvj4wOWhAC0LJ1g==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"
@@ -3940,9 +3940,9 @@ camelcase@^6.0.0:
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
 caniuse-lite@^1.0.30001317:
-  version "1.0.30001325"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001325.tgz#2b4ad19b77aa36f61f2eaf72e636d7481d55e606"
-  integrity sha512-sB1bZHjseSjDtijV1Hb7PB2Zd58Kyx+n/9EotvZ4Qcz2K3d0lWB8dB4nb8wN/TsOGFq3UuAm0zQZNQ4SoR7TrQ==
+  version "1.0.30001327"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001327.tgz#c1546d7d7bb66506f0ccdad6a7d07fc6d668c858"
+  integrity sha512-1/Cg4jlD9qjZzhbzkzEaAC2JHsP0WrOc8Rd/3a3LuajGzGWR/hD7TVyvq99VqmTy99eVh8Zkmdq213OgvgXx7w==
 
 caseless@~0.12.0:
   version "0.12.0"
@@ -5205,9 +5205,9 @@ eslint-visitor-keys@^3.0.0, eslint-visitor-keys@^3.3.0:
   integrity sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==
 
 eslint@^8.10.0:
-  version "8.12.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.12.0.tgz#c7a5bd1cfa09079aae64c9076c07eada66a46e8e"
-  integrity sha512-it1oBL9alZg1S8UycLm5YDMAkIhtH6FtAzuZs6YvoGVldWjbS08BkAdb/ymP9LlAyq8koANu32U7Ib/w+UNh8Q==
+  version "8.13.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.13.0.tgz#6fcea43b6811e655410f5626cfcf328016badcd7"
+  integrity sha512-D+Xei61eInqauAyTJ6C0q6x9mx7kTUC1KZ0m0LSEexR0V+e94K12LmWX076ZIsldwfQ2RONdaJe0re0TRGQbRQ==
   dependencies:
     "@eslint/eslintrc" "^1.2.1"
     "@humanwhocodes/config-array" "^0.9.2"
@@ -7115,9 +7115,9 @@ lru-cache@^6.0.0:
     yallist "^4.0.0"
 
 lru-cache@^7.4.0:
-  version "7.7.3"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-7.7.3.tgz#98cd19eef89ce6a4a3c4502c17c833888677c252"
-  integrity sha512-WY9wjJNQt9+PZilnLbuFKM+SwDull9+6IAguOrarOMoOHTcJ9GnXSO11+Gw6c7xtDkBkthR57OZMtZKYr+1CEw==
+  version "7.8.1"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-7.8.1.tgz#68ee3f4807a57d2ba185b7fd90827d5c21ce82bb"
+  integrity sha512-E1v547OCgJvbvevfjgK9sNKIVXO96NnsTsFPBlg4ZxjhsJSODoH9lk8Bm0OxvHNm6Vm5Yqkl/1fErDxhYL8Skg==
 
 lzma-native@^8.0.5:
   version "8.0.6"
@@ -10374,9 +10374,9 @@ uc.micro@^1.0.1, uc.micro@^1.0.5:
   integrity sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==
 
 uglify-js@^3.1.4:
-  version "3.15.3"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.15.3.tgz#9aa82ca22419ba4c0137642ba0df800cb06e0471"
-  integrity sha512-6iCVm2omGJbsu3JWac+p6kUiOpg3wFO2f8lIXjfEb8RrmLjzog1wTPMmwKB7swfzzqxj9YM+sGUM++u1qN4qJg==
+  version "3.15.4"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.15.4.tgz#fa95c257e88f85614915b906204b9623d4fa340d"
+  integrity sha512-vMOPGDuvXecPs34V74qDKk4iJ/SN4vL3Ow/23ixafENYvtrNvtbcgUeugTcUGRGsOF/5fU8/NYSL5Hyb3l1OJA==
 
 uid-number@0.0.6:
   version "0.0.6"
@@ -10696,9 +10696,9 @@ webpack-sources@^3.2.3:
   integrity sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==
 
 webpack@^5.48.0:
-  version "5.71.0"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.71.0.tgz#b01fcf379570b8c5ee06ca06c829ca168c951884"
-  integrity sha512-g4dFT7CFG8LY0iU5G8nBL6VlkT21Z7dcYDpJAEJV5Q1WLb9UwnFbrem1k7K52ILqEmomN7pnzWFxxE6SlDY56A==
+  version "5.72.0"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.72.0.tgz#f8bc40d9c6bb489a4b7a8a685101d6022b8b6e28"
+  integrity sha512-qmSmbspI0Qo5ld49htys8GY9XhS9CGqFoHTsOVAnjBdg0Zn79y135R+k4IR4rKK6+eKaabMhJwiVB7xw0SJu5w==
   dependencies:
     "@types/eslint-scope" "^3.7.3"
     "@types/estree" "^0.0.51"
@@ -11120,9 +11120,9 @@ yargs@^15.3.1:
     yargs-parser "^18.1.2"
 
 yargs@^17.0.1:
-  version "17.4.0"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.4.0.tgz#9fc9efc96bd3aa2c1240446af28499f0e7593d00"
-  integrity sha512-WJudfrk81yWFSOkZYpAZx4Nt7V4xp7S/uJkX0CnxovMCt1wCE8LNftPpNuF9X/u9gN5nsD7ycYtRcDf2pL3UiA==
+  version "17.4.1"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.4.1.tgz#ebe23284207bb75cee7c408c33e722bfb27b5284"
+  integrity sha512-WSZD9jgobAg3ZKuCQZSa3g9QOJeCCqLoLAykiWgmXnDo9EPnn4RPf5qVTtzgOx66o6/oqhcA5tHtJXpG8pMt3g==
   dependencies:
     cliui "^7.0.2"
     escalade "^3.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -22,30 +22,30 @@
   integrity sha512-p8pdE6j0a29TNGebNm7NzYZWB3xVZJBZ7XGs42uAKzQo8VQ3F0By/cQCtUEABwIqw5zo6WA4NbmxsfzADzMKnQ==
 
 "@babel/core@^7.10.0":
-  version "7.17.8"
-  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.17.8.tgz#3dac27c190ebc3a4381110d46c80e77efe172e1a"
-  integrity sha512-OdQDV/7cRBtJHLSOBqqbYNkOcydOgnX59TZx4puf41fzcVtN3e/4yqY8lMQsK+5X2lJtAdmA+6OHqsj1hBJ4IQ==
+  version "7.17.9"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.17.9.tgz#6bae81a06d95f4d0dec5bb9d74bbc1f58babdcfe"
+  integrity sha512-5ug+SfZCpDAkVp9SFIZAzlW18rlzsOcJGaetCjkySnrXXDUw9AR8cDUm1iByTmdWM6yxX6/zycaV76w3YTF2gw==
   dependencies:
     "@ampproject/remapping" "^2.1.0"
     "@babel/code-frame" "^7.16.7"
-    "@babel/generator" "^7.17.7"
+    "@babel/generator" "^7.17.9"
     "@babel/helper-compilation-targets" "^7.17.7"
     "@babel/helper-module-transforms" "^7.17.7"
-    "@babel/helpers" "^7.17.8"
-    "@babel/parser" "^7.17.8"
+    "@babel/helpers" "^7.17.9"
+    "@babel/parser" "^7.17.9"
     "@babel/template" "^7.16.7"
-    "@babel/traverse" "^7.17.3"
+    "@babel/traverse" "^7.17.9"
     "@babel/types" "^7.17.0"
     convert-source-map "^1.7.0"
     debug "^4.1.0"
     gensync "^1.0.0-beta.2"
-    json5 "^2.1.2"
+    json5 "^2.2.1"
     semver "^6.3.0"
 
-"@babel/generator@^7.17.3", "@babel/generator@^7.17.7":
-  version "7.17.7"
-  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.17.7.tgz#8da2599beb4a86194a3b24df6c085931d9ee45ad"
-  integrity sha512-oLcVCTeIFadUoArDTwpluncplrYBmTCCZZgXCbgNGvOBBiSDDK3eWO4b/+eOTli5tKv1lg+a5/NAXg+nTcei1w==
+"@babel/generator@^7.17.9":
+  version "7.17.9"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.17.9.tgz#f4af9fd38fa8de143c29fce3f71852406fc1e2fc"
+  integrity sha512-rAdDousTwxbIxbz5I7GEQ3lUip+xVCXooZNbsydCWs3xA7ZsYOv+CFRdzGxRX78BmQHu9B1Eso59AOZQOJDEdQ==
   dependencies:
     "@babel/types" "^7.17.0"
     jsesc "^2.5.1"
@@ -77,14 +77,14 @@
     semver "^6.3.0"
 
 "@babel/helper-create-class-features-plugin@^7.16.10", "@babel/helper-create-class-features-plugin@^7.16.7", "@babel/helper-create-class-features-plugin@^7.17.6":
-  version "7.17.6"
-  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.17.6.tgz#3778c1ed09a7f3e65e6d6e0f6fbfcc53809d92c9"
-  integrity sha512-SogLLSxXm2OkBbSsHZMM4tUi8fUzjs63AT/d0YQIzr6GSd8Hxsbk2KYDX0k0DweAzGMj/YWeiCsorIdtdcW8Eg==
+  version "7.17.9"
+  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.17.9.tgz#71835d7fb9f38bd9f1378e40a4c0902fdc2ea49d"
+  integrity sha512-kUjip3gruz6AJKOq5i3nC6CoCEEF/oHH3cp6tOZhB+IyyyPyW0g1Gfsxn3mkk6S08pIA2y8GQh609v9G/5sHVQ==
   dependencies:
     "@babel/helper-annotate-as-pure" "^7.16.7"
     "@babel/helper-environment-visitor" "^7.16.7"
-    "@babel/helper-function-name" "^7.16.7"
-    "@babel/helper-member-expression-to-functions" "^7.16.7"
+    "@babel/helper-function-name" "^7.17.9"
+    "@babel/helper-member-expression-to-functions" "^7.17.7"
     "@babel/helper-optimise-call-expression" "^7.16.7"
     "@babel/helper-replace-supers" "^7.16.7"
     "@babel/helper-split-export-declaration" "^7.16.7"
@@ -125,21 +125,13 @@
   dependencies:
     "@babel/types" "^7.16.7"
 
-"@babel/helper-function-name@^7.16.7":
-  version "7.16.7"
-  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.16.7.tgz#f1ec51551fb1c8956bc8dd95f38523b6cf375f8f"
-  integrity sha512-QfDfEnIUyyBSR3HtrtGECuZ6DAyCkYFp7GHl75vFtTnn6pjKeK0T1DB5lLkFvBea8MdaiUABx3osbgLyInoejA==
+"@babel/helper-function-name@^7.16.7", "@babel/helper-function-name@^7.17.9":
+  version "7.17.9"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.17.9.tgz#136fcd54bc1da82fcb47565cf16fd8e444b1ff12"
+  integrity sha512-7cRisGlVtiVqZ0MW0/yFB4atgpGLWEHUVYnb448hZK4x+vih0YO5UoS11XIYtZYqHd0dIPMdUSv8q5K4LdMnIg==
   dependencies:
-    "@babel/helper-get-function-arity" "^7.16.7"
     "@babel/template" "^7.16.7"
-    "@babel/types" "^7.16.7"
-
-"@babel/helper-get-function-arity@^7.16.7":
-  version "7.16.7"
-  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.7.tgz#ea08ac753117a669f1508ba06ebcc49156387419"
-  integrity sha512-flc+RLSOBXzNzVhcLu6ujeHUrD6tANAOU5ojrRx/as+tbzf8+stUCj7+IfRRoAbEZqj/ahXEMsjhOhgeZsrnTw==
-  dependencies:
-    "@babel/types" "^7.16.7"
+    "@babel/types" "^7.17.0"
 
 "@babel/helper-hoist-variables@^7.16.7":
   version "7.16.7"
@@ -148,7 +140,7 @@
   dependencies:
     "@babel/types" "^7.16.7"
 
-"@babel/helper-member-expression-to-functions@^7.16.7":
+"@babel/helper-member-expression-to-functions@^7.16.7", "@babel/helper-member-expression-to-functions@^7.17.7":
   version "7.17.7"
   resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.17.7.tgz#a34013b57d8542a8c4ff8ba3f747c02452a4d8c4"
   integrity sha512-thxXgnQ8qQ11W2wVUObIqDL4p148VMxkt5T/qpN5k2fboRyzFGFmKsTGViquyM5QHKUy48OZoca8kw4ajaDPyw==
@@ -249,28 +241,28 @@
     "@babel/traverse" "^7.16.8"
     "@babel/types" "^7.16.8"
 
-"@babel/helpers@^7.17.8":
-  version "7.17.8"
-  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.17.8.tgz#288450be8c6ac7e4e44df37bcc53d345e07bc106"
-  integrity sha512-QcL86FGxpfSJwGtAvv4iG93UL6bmqBdmoVY0CMCU2g+oD2ezQse3PT5Pa+jiD6LJndBQi0EDlpzOWNlLuhz5gw==
+"@babel/helpers@^7.17.9":
+  version "7.17.9"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.17.9.tgz#b2af120821bfbe44f9907b1826e168e819375a1a"
+  integrity sha512-cPCt915ShDWUEzEp3+UNRktO2n6v49l5RSnG9M5pS24hA+2FAc5si+Pn1i4VVbQQ+jh+bIZhPFQOJOzbrOYY1Q==
   dependencies:
     "@babel/template" "^7.16.7"
-    "@babel/traverse" "^7.17.3"
+    "@babel/traverse" "^7.17.9"
     "@babel/types" "^7.17.0"
 
 "@babel/highlight@^7.16.7":
-  version "7.16.10"
-  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.16.10.tgz#744f2eb81579d6eea753c227b0f570ad785aba88"
-  integrity sha512-5FnTQLSLswEj6IkgVw5KusNUUFY9ZGqe/TRFnP/BKYHYgfh7tc+C7mwiy95/yNP7Dh9x580Vv8r7u7ZfTBFxdw==
+  version "7.17.9"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.17.9.tgz#61b2ee7f32ea0454612def4fccdae0de232b73e3"
+  integrity sha512-J9PfEKCbFIv2X5bjTMiZu6Vf341N05QIY+d6FvVKynkG1S7G0j3I0QoRtWIrXhZ+/Nlb5Q0MzqL7TokEJ5BNHg==
   dependencies:
     "@babel/helper-validator-identifier" "^7.16.7"
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.16.7", "@babel/parser@^7.17.3", "@babel/parser@^7.17.8":
-  version "7.17.8"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.17.8.tgz#2817fb9d885dd8132ea0f8eb615a6388cca1c240"
-  integrity sha512-BoHhDJrJXqcg+ZL16Xv39H9n+AqJ4pcDrQBGZN+wHxIysrLZ3/ECwCBUch/1zUNhnsXULcONU3Ei5Hmkfk6kiQ==
+"@babel/parser@^7.16.7", "@babel/parser@^7.17.9":
+  version "7.17.9"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.17.9.tgz#9c94189a6062f0291418ca021077983058e171ef"
+  integrity sha512-vqUSBLP8dQHFPdPi9bc5GK9vRkYHJ49fsZdtoJ8EQ8ibpwk5rPKfvNIwChB0KVXcIjcepEBBd2VHC5r9Gy8ueg==
 
 "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@^7.16.7":
   version "7.16.7"
@@ -635,9 +627,9 @@
     babel-plugin-dynamic-import-node "^2.3.3"
 
 "@babel/plugin-transform-modules-commonjs@^7.16.8":
-  version "7.17.7"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.17.7.tgz#d86b217c8e45bb5f2dbc11eefc8eab62cf980d19"
-  integrity sha512-ITPmR2V7MqioMJyrxUo2onHNC3e+MvfFiFIR0RP21d3PtlVb6sfzoxNKiphSZUOM9hEIdzCcZe83ieX3yoqjUA==
+  version "7.17.9"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.17.9.tgz#274be1a2087beec0254d4abd4d86e52442e1e5b6"
+  integrity sha512-2TBFd/r2I6VlYn0YRTz2JdazS+FoUuQ2rIFHoAxtyP/0G3D82SBLaRq9rnUkpqlLg03Byfl/+M32mpxjO6KaPw==
   dependencies:
     "@babel/helper-module-transforms" "^7.17.7"
     "@babel/helper-plugin-utils" "^7.16.7"
@@ -700,11 +692,11 @@
     "@babel/helper-plugin-utils" "^7.16.7"
 
 "@babel/plugin-transform-regenerator@^7.16.7":
-  version "7.16.7"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.16.7.tgz#9e7576dc476cb89ccc5096fff7af659243b4adeb"
-  integrity sha512-mF7jOgGYCkSJagJ6XCujSQg+6xC1M77/03K2oBmVJWoFGNUtnVJO4WHKJk3dnPC8HCcj4xBQP1Egm8DWh3Pb3Q==
+  version "7.17.9"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.17.9.tgz#0a33c3a61cf47f45ed3232903683a0afd2d3460c"
+  integrity sha512-Lc2TfbxR1HOyn/c6b4Y/b6NHoTb67n/IoWLxTu4kC7h4KQnWlhCq2S8Tx0t2SVvv5Uu87Hs+6JEJ5kt2tYGylQ==
   dependencies:
-    regenerator-transform "^0.14.2"
+    regenerator-transform "^0.15.0"
 
 "@babel/plugin-transform-reserved-words@^7.16.7":
   version "7.16.7"
@@ -868,9 +860,9 @@
     esutils "^2.0.2"
 
 "@babel/runtime@^7.10.0", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7":
-  version "7.17.8"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.17.8.tgz#3e56e4aff81befa55ac3ac6a0967349fd1c5bca2"
-  integrity sha512-dQpEpK0O9o6lj6oPu0gRDbbnk+4LeHlNcBpspf6Olzt3GIX4P1lWF1gS+pHLDFlaJvbR6q7jCfQ08zA4QJBnmA==
+  version "7.17.9"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.17.9.tgz#d19fbf802d01a8cb6cf053a64e472d42c434ba72"
+  integrity sha512-lSiBBvodq29uShpWGNbgFdKYNiFDo5/HIYsaCEY9ff4sb10x9jizo2+pRrSyF4jKZCXqgzuqBOQKbUm90gQwJg==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -883,18 +875,18 @@
     "@babel/parser" "^7.16.7"
     "@babel/types" "^7.16.7"
 
-"@babel/traverse@^7.13.0", "@babel/traverse@^7.16.7", "@babel/traverse@^7.16.8", "@babel/traverse@^7.17.3":
-  version "7.17.3"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.17.3.tgz#0ae0f15b27d9a92ba1f2263358ea7c4e7db47b57"
-  integrity sha512-5irClVky7TxRWIRtxlh2WPUUOLhcPN06AGgaQSB8AEwuyEBgJVuJ5imdHm5zxk8w0QS5T+tDfnDxAlhWjpb7cw==
+"@babel/traverse@^7.13.0", "@babel/traverse@^7.16.7", "@babel/traverse@^7.16.8", "@babel/traverse@^7.17.3", "@babel/traverse@^7.17.9":
+  version "7.17.9"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.17.9.tgz#1f9b207435d9ae4a8ed6998b2b82300d83c37a0d"
+  integrity sha512-PQO8sDIJ8SIwipTPiR71kJQCKQYB5NGImbOviK8K+kg5xkNSYXLBupuX9QhatFowrsvo9Hj8WgArg3W7ijNAQw==
   dependencies:
     "@babel/code-frame" "^7.16.7"
-    "@babel/generator" "^7.17.3"
+    "@babel/generator" "^7.17.9"
     "@babel/helper-environment-visitor" "^7.16.7"
-    "@babel/helper-function-name" "^7.16.7"
+    "@babel/helper-function-name" "^7.17.9"
     "@babel/helper-hoist-variables" "^7.16.7"
     "@babel/helper-split-export-declaration" "^7.16.7"
-    "@babel/parser" "^7.17.3"
+    "@babel/parser" "^7.17.9"
     "@babel/types" "^7.17.0"
     debug "^4.1.0"
     globals "^11.1.0"
@@ -925,19 +917,19 @@
   integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==
 
 "@eclipse-glsp-examples/workflow-glsp@next":
-  version "0.10.0-next.88e4725.166"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp-examples/workflow-glsp/-/workflow-glsp-0.10.0-next.88e4725.166.tgz#fe06172488b7272258692a3090058976793c1627"
-  integrity sha512-JoOrVaycrc6Wpm6zeG/pxt0TYij9fCCHBR+Gn7mv7cyxgNBpR8OTV3am00WOQDWv68rWVG90rCTEaTyc283vMw==
+  version "0.10.0-next.385713d.170"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp-examples/workflow-glsp/-/workflow-glsp-0.10.0-next.385713d.170.tgz#454b4505dc2b0968bb88616aa15551002ae86884"
+  integrity sha512-w7aByoDnfeO8YHL3AuHSI2dnXElGD1HH102ojTJ+sLBk61Ada/LrSF7LlhHMEnKI0riLai3YlDweZKr2f0B0OQ==
   dependencies:
-    "@eclipse-glsp/client" "0.10.0-next.88e4725.166+88e4725"
+    "@eclipse-glsp/client" "0.10.0-next.385713d.170+385713d"
     balloon-css "^0.5.0"
 
-"@eclipse-glsp/client@0.10.0-next.88e4725.166+88e4725", "@eclipse-glsp/client@next":
-  version "0.10.0-next.88e4725.166"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp/client/-/client-0.10.0-next.88e4725.166.tgz#5863cbae21aab1b53a121772198a16611544b414"
-  integrity sha512-uJ+s/BiyOIaFL1B09/qJkdnsQ6xaJFWjC70E1KqrZ5DJbNEsha89rs3y4wYs++uYvN7rrfW029qnJr1B/w1UEg==
+"@eclipse-glsp/client@0.10.0-next.385713d.170+385713d", "@eclipse-glsp/client@next":
+  version "0.10.0-next.385713d.170"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp/client/-/client-0.10.0-next.385713d.170.tgz#bd9b7a987c6263cce6c87cedd22341622f1a2d38"
+  integrity sha512-iZFLN0lIRDNTdtBToLXv0rkA5jBvVuLOKmneORnLant0fMbJH6LN7WisnpItjnyI6aObIA13Mt6BJp+MD29H/A==
   dependencies:
-    "@eclipse-glsp/protocol" "0.10.0-next.88e4725.166+88e4725"
+    "@eclipse-glsp/protocol" "0.10.0-next.385713d.170+385713d"
     autocompleter "5.1.0"
     sprotty next
 
@@ -987,10 +979,10 @@
   resolved "https://registry.yarnpkg.com/@eclipse-glsp/prettier-config/-/prettier-config-0.10.0-next.b7bb985.103.tgz#2ad708ca691e8fe228b98e0ce673dbba43a2ef8c"
   integrity sha512-GrIHVf41ZYfoHIs97JXukUAmTS6IHQ4n1MnIJcNILJ38lLoFb254QYWdpLybbtu8xmXMdqPOHlrJE1J6TrB5Ow==
 
-"@eclipse-glsp/protocol@0.10.0-next.88e4725.166+88e4725":
-  version "0.10.0-next.88e4725.166"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp/protocol/-/protocol-0.10.0-next.88e4725.166.tgz#0a9cf798e5219d1bd298702993c2f6e9fba7d120"
-  integrity sha512-NRTl8W01eifVIkhDnPu0M4qFlmS2ra4YVxN5jJCWtnXnjJjvs9cqDu//nvOUK+Ufo0U0hrLyivDglcYJfDVcKA==
+"@eclipse-glsp/protocol@0.10.0-next.385713d.170+385713d":
+  version "0.10.0-next.385713d.170"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp/protocol/-/protocol-0.10.0-next.385713d.170.tgz#07adeb29c05fb3a163959e390f7a28e84a7d5468"
+  integrity sha512-40ztBb5zna2b3BQDmdwRHp7a7JmHRDInoRwxG5Ub/KgSd1qiqv0wSXqhdYIBu4BQvzhS473zN/x/DBJVHYuyOA==
   dependencies:
     sprotty-protocol next
     uuid "7.0.3"
@@ -2136,17 +2128,17 @@
   dependencies:
     defer-to-connect "^2.0.0"
 
-"@theia/application-manager@1.23.0":
-  version "1.23.0"
-  resolved "https://registry.yarnpkg.com/@theia/application-manager/-/application-manager-1.23.0.tgz#377c6498f6759d6d28f39ed97cac210e4d45660a"
-  integrity sha512-UVUHbAu7tfo0OKSBNmVtyN/LkSQFvEj91d9pNrn34w43v8h8xg/DroVJji/AnrtRCS5h0UpWV8gwQX7pB/l56g==
+"@theia/application-manager@1.24.0":
+  version "1.24.0"
+  resolved "https://registry.yarnpkg.com/@theia/application-manager/-/application-manager-1.24.0.tgz#43ca874bde6609555732fef6f2bf4fee4b6f6ad3"
+  integrity sha512-wnC17wSiclvueGXLGv+tJEo6k+CEz9TlsLo/EeXak1TfopljyMZLNNw7x6kJaA9mVNIUWJas5Eu+kFcv4KzkdQ==
   dependencies:
     "@babel/core" "^7.10.0"
     "@babel/plugin-transform-classes" "^7.10.0"
     "@babel/plugin-transform-runtime" "^7.10.0"
     "@babel/preset-env" "^7.10.0"
-    "@theia/application-package" "1.23.0"
-    "@theia/ffmpeg" "1.23.0"
+    "@theia/application-package" "1.24.0"
+    "@theia/ffmpeg" "1.24.0"
     "@types/fs-extra" "^4.0.2"
     "@types/semver" "^7.3.8"
     babel-loader "^8.2.2"
@@ -2173,10 +2165,10 @@
     worker-loader "^3.0.8"
     yargs "^15.3.1"
 
-"@theia/application-package@1.23.0":
-  version "1.23.0"
-  resolved "https://registry.yarnpkg.com/@theia/application-package/-/application-package-1.23.0.tgz#fc363e3ba8fa25eb09940de1831365ec8152d4ca"
-  integrity sha512-jUZ+/NVK3y9XWjdagKTVidLJwW1JYCKfPGVA4tHLqlnpHOgbM3T87DvMz5IaahHiHo2Y4w7LC1abaQaBHeua3Q==
+"@theia/application-package@1.24.0":
+  version "1.24.0"
+  resolved "https://registry.yarnpkg.com/@theia/application-package/-/application-package-1.24.0.tgz#c94caacfede7fce2d7f0444acf71c964dc6d753c"
+  integrity sha512-jYOJlJX21pi5vQNtT3k8XcfRghoNjs8KN/j4l1ox9YcmezjeAIA4mh2PVxgGLO8W0kiPstc2c2bXPBMIqFDJNA==
   dependencies:
     "@types/fs-extra" "^4.0.2"
     "@types/request" "^2.0.3"
@@ -2190,16 +2182,16 @@
     semver "^5.4.1"
     write-json-file "^2.2.0"
 
-"@theia/cli@^1.0.0":
-  version "1.23.0"
-  resolved "https://registry.yarnpkg.com/@theia/cli/-/cli-1.23.0.tgz#637ab22273229bcfe89c2e1901ce79fe675c6bb3"
-  integrity sha512-WVl984ctdxZu+EMDL5dd/P0BrQ14mhj9d5alRL9Z8JPsIKg/UGG5hyHQBqET2lb94UPqW+ksi0THwR6mCnUrOA==
+"@theia/cli@^1.24.0":
+  version "1.24.0"
+  resolved "https://registry.yarnpkg.com/@theia/cli/-/cli-1.24.0.tgz#0eb13786daf778700b6b541180d9dcbfedab5dae"
+  integrity sha512-5R2bCR3x6NOka6ZDZX3/kvBOl03lQ+wYMbET8PumXNz420aGRNQ7RtLxer5CV2Q6odSKkqAywTfEhrxiMb6IUQ==
   dependencies:
-    "@theia/application-manager" "1.23.0"
-    "@theia/application-package" "1.23.0"
-    "@theia/ffmpeg" "1.23.0"
-    "@theia/localization-manager" "1.23.0"
-    "@theia/ovsx-client" "1.23.0"
+    "@theia/application-manager" "1.24.0"
+    "@theia/application-package" "1.24.0"
+    "@theia/ffmpeg" "1.24.0"
+    "@theia/localization-manager" "1.24.0"
+    "@theia/ovsx-client" "1.24.0"
     "@types/chai" "^4.2.7"
     "@types/mocha" "^5.2.7"
     "@types/node-fetch" "^2.5.7"
@@ -2216,10 +2208,10 @@
     temp "^0.9.1"
     yargs "^15.3.1"
 
-"@theia/core@1.23.0", "@theia/core@^1.0.0", "@theia/core@^1.18.0":
-  version "1.23.0"
-  resolved "https://registry.yarnpkg.com/@theia/core/-/core-1.23.0.tgz#ef79f11370df98f391b12f7050d196dd001ad2e1"
-  integrity sha512-yheuGb09/eCsBFMlj6OcI35hL7L/psPllpGaiBleldcKnTbeYKsY1KRSPl3FFHFAWfE1uFb6/3RaDVVVdlD4ew==
+"@theia/core@1.24.0", "@theia/core@^1.18.0", "@theia/core@^1.24.0":
+  version "1.24.0"
+  resolved "https://registry.yarnpkg.com/@theia/core/-/core-1.24.0.tgz#ff278a6572b1088c2805a674207d69153cab2537"
+  integrity sha512-HLId45qq3Sx0agclgWScWeatUyLktUg1iFnUz+UK+c84ZJF00wywym1r85LOcg/ny6jYLYnuyvGW0vGxyJ1/lA==
   dependencies:
     "@babel/runtime" "^7.10.0"
     "@phosphor/algorithm" "1"
@@ -2233,7 +2225,7 @@
     "@phosphor/virtualdom" "1"
     "@phosphor/widgets" "1"
     "@primer/octicons-react" "^9.0.0"
-    "@theia/application-package" "1.23.0"
+    "@theia/application-package" "1.24.0"
     "@types/body-parser" "^1.16.4"
     "@types/cookie" "^0.3.3"
     "@types/dompurify" "^2.2.2"
@@ -2288,28 +2280,28 @@
     ws "^7.1.2"
     yargs "^15.3.1"
 
-"@theia/editor@1.23.0", "@theia/editor@^1.0.0", "@theia/editor@^1.18.0":
-  version "1.23.0"
-  resolved "https://registry.yarnpkg.com/@theia/editor/-/editor-1.23.0.tgz#71f07337db761220bd5950686a9c06f3fefc261a"
-  integrity sha512-v3ra+pXu/uCtKYUtc5Me48Do5XiRVWJcVSNAU86qB2Qc8mWWHq6FueaN7Oh1sSJv4Xu6Gs1CVow3/u0/w4awfQ==
+"@theia/editor@1.24.0", "@theia/editor@^1.18.0", "@theia/editor@^1.24.0":
+  version "1.24.0"
+  resolved "https://registry.yarnpkg.com/@theia/editor/-/editor-1.24.0.tgz#b4138531d2d1e11e747501696e84ec3bfa7672e6"
+  integrity sha512-RMyK9GwOY+daU+UXQHoLu4hKN9Xebl+nYvMK/goBWyz7YnkvcQVRa505xyT2vw8h9KOVOEcCp1u2eA4zM+RZew==
   dependencies:
-    "@theia/core" "1.23.0"
-    "@theia/variable-resolver" "1.23.0"
+    "@theia/core" "1.24.0"
+    "@theia/variable-resolver" "1.24.0"
 
-"@theia/ffmpeg@1.23.0":
-  version "1.23.0"
-  resolved "https://registry.yarnpkg.com/@theia/ffmpeg/-/ffmpeg-1.23.0.tgz#3ce396611902535df2884258bc2db5c0caf4bdde"
-  integrity sha512-KiylGPGdJZffLAQ2eiRZHbazLx9msvkFGlsG+/qNwksI7Tup2OdWYD77+316yvnm1a+1gqSUC1zyUIAbPje0TA==
+"@theia/ffmpeg@1.24.0":
+  version "1.24.0"
+  resolved "https://registry.yarnpkg.com/@theia/ffmpeg/-/ffmpeg-1.24.0.tgz#90ad810fe106ef985fdd3cc1281f4b445658d54e"
+  integrity sha512-uyEP56GBfzipNPncgL0W58GlTtqrgiK8tBXCKew/oXnjtFEzPwiZrjlEljV7yxVoKyPCRec67TbZXd1GTieuLQ==
   dependencies:
     "@electron/get" "^1.12.4"
     unzipper "^0.9.11"
 
-"@theia/filesystem@1.23.0", "@theia/filesystem@^1.0.0", "@theia/filesystem@^1.18.0":
-  version "1.23.0"
-  resolved "https://registry.yarnpkg.com/@theia/filesystem/-/filesystem-1.23.0.tgz#270bafe7b0be7d2e66666677e917c2d1656b2b06"
-  integrity sha512-a6chJIgzthYqi9R0czgS3SgCEEjXHaxwmo0praQ1X3q5lFTJGxyKS6L9Dgnw4tCgBODrFKMow5VIIRw7wpUSeQ==
+"@theia/filesystem@1.24.0", "@theia/filesystem@^1.18.0", "@theia/filesystem@^1.24.0":
+  version "1.24.0"
+  resolved "https://registry.yarnpkg.com/@theia/filesystem/-/filesystem-1.24.0.tgz#5027545d8d6deb0ccfacfcce4e6a873df572277b"
+  integrity sha512-XCKISKighFscmxNIlYh+eLyq6dr2mzupjnPHT7VgOChNnN0vOaSOyISt9U9gzu8+nTq1Ww73HIisgW/T4UP8UQ==
   dependencies:
-    "@theia/core" "1.23.0"
+    "@theia/core" "1.24.0"
     "@types/body-parser" "^1.17.0"
     "@types/multer" "^1.4.7"
     "@types/rimraf" "^2.0.2"
@@ -2326,10 +2318,10 @@
     uuid "^8.0.0"
     vscode-languageserver-textdocument "^1.0.1"
 
-"@theia/localization-manager@1.23.0":
-  version "1.23.0"
-  resolved "https://registry.yarnpkg.com/@theia/localization-manager/-/localization-manager-1.23.0.tgz#8a6b98bacf4aa09948755ead82e17bdc4525383e"
-  integrity sha512-5N3RI7foby0iWUX8uijYOJgye0k5w6ijVwmsdDgQuNIYTOh1CCdFeZnRIflVyg9fc3yR44zIzFXbvHeLxEXslg==
+"@theia/localization-manager@1.24.0":
+  version "1.24.0"
+  resolved "https://registry.yarnpkg.com/@theia/localization-manager/-/localization-manager-1.24.0.tgz#ef08a65c70483462d4bd206b6cc2cb786107f13c"
+  integrity sha512-cR92jGTaWNxpa/6xhizEAy6WOo8UemFeR2RSHQqK9kuIt0hP7IsIK4vmwsqlGbL3Dceusd4II5o/IhpIfqNScg==
   dependencies:
     "@types/bent" "^7.0.1"
     "@types/fs-extra" "^4.0.2"
@@ -2340,134 +2332,135 @@
     glob "^7.2.0"
     typescript "~4.5.5"
 
-"@theia/markers@1.23.0", "@theia/markers@^1.0.0":
-  version "1.23.0"
-  resolved "https://registry.yarnpkg.com/@theia/markers/-/markers-1.23.0.tgz#5ea4784517f0618ee179b7d168939227ddbcf723"
-  integrity sha512-c4usDBwsAwnaYuts+c7XEnNoAo98z/keOIwvUFnW+C+KEBu2Himq+bwmPKFNC2KSiLGwvBpRkDHzieTIvEnjlg==
+"@theia/markers@1.24.0", "@theia/markers@^1.24.0":
+  version "1.24.0"
+  resolved "https://registry.yarnpkg.com/@theia/markers/-/markers-1.24.0.tgz#65d15b6d0697543df41c315a6d79cbe213efb169"
+  integrity sha512-DY61feUngeWLXXTqEm+Yh78TDRmnIoy/dLDZvrnG7o4qWlVWM8M4SpycVvdpI3geA9BTt78XiSQJq8cJfak6/A==
   dependencies:
-    "@theia/core" "1.23.0"
-    "@theia/filesystem" "1.23.0"
-    "@theia/navigator" "1.23.0"
-    "@theia/workspace" "1.23.0"
+    "@theia/core" "1.24.0"
+    "@theia/filesystem" "1.24.0"
+    "@theia/navigator" "1.24.0"
+    "@theia/workspace" "1.24.0"
 
-"@theia/messages@^1.0.0":
-  version "1.23.0"
-  resolved "https://registry.yarnpkg.com/@theia/messages/-/messages-1.23.0.tgz#879e3e5a0b03a04bbe92e36464ed26f7eb8d8f22"
-  integrity sha512-d/Z3M/qlXVcUMENDjfGJcrLCA+QThHyiJy7FhCA7Lhsul4xdymOmahHk3t0Wy6Tn86sAnbgsrivuukp8RYngIA==
+"@theia/messages@^1.24.0":
+  version "1.24.0"
+  resolved "https://registry.yarnpkg.com/@theia/messages/-/messages-1.24.0.tgz#fa5463bfb9d4d237398a7428b0c0b7ff5269aa81"
+  integrity sha512-jeV7DQrqTHu6VgRNXGdTMb4x5aDc43CMbDMKUMYAjZZ5Xfu0d0ZFoo5AHhu4WcNbHhMlAFmK7D7zYLz7LPpoxg==
   dependencies:
-    "@theia/core" "1.23.0"
+    "@theia/core" "1.24.0"
     react-perfect-scrollbar "^1.5.3"
     ts-md5 "^1.2.2"
 
-"@theia/monaco-editor-core@0.23.0":
-  version "0.23.0"
-  resolved "https://registry.yarnpkg.com/@theia/monaco-editor-core/-/monaco-editor-core-0.23.0.tgz#7a1cbb7a857a509ce8e75c9965abea752bd76e80"
-  integrity sha512-WyrotTd6ZfeXAX4icgFALTzlqE356tAQ5nRuwa2E0Qdp2YIO9GDcw5G2l2NJ8INO2ygujbE5pEdD5kJM5N4TOQ==
+"@theia/monaco-editor-core@1.65.2":
+  version "1.65.2"
+  resolved "https://registry.yarnpkg.com/@theia/monaco-editor-core/-/monaco-editor-core-1.65.2.tgz#91bc9ce2afe1b6011789ce83a5bee898f0153430"
+  integrity sha512-2UmGjcEW/YpZ2DsFuVevKR3CBMe44Rd6DgwP/5s4pyOe6K/s6TKY7Sh24lO0BXetQKofAEx3zh+ldEvjwhNwDw==
 
-"@theia/monaco@1.23.0", "@theia/monaco@^1.0.0", "@theia/monaco@^1.18.0":
-  version "1.23.0"
-  resolved "https://registry.yarnpkg.com/@theia/monaco/-/monaco-1.23.0.tgz#7e2a8dfc8cc49ab48566913b05d1f982dc43f90e"
-  integrity sha512-AIDjtuGsFj8PX40ZeAvoXt5FB4gh7A32AiEZpKJAr/Ktp50eX7roWv43OyiptdhZC8BoQ362mc+oVUArUJzUlQ==
+"@theia/monaco@1.24.0", "@theia/monaco@^1.18.0", "@theia/monaco@^1.24.0":
+  version "1.24.0"
+  resolved "https://registry.yarnpkg.com/@theia/monaco/-/monaco-1.24.0.tgz#bbf94bf5c5f2612721d0ab2d6c01d75036b965af"
+  integrity sha512-GCESpgd3+R6MJ5jtMHEQUQ0sbREtA78ZcnoTYw7O+0bOIMtFa4IHNTfcAbET2SgMrjsWjrzByrp42MxXLJoEyw==
   dependencies:
-    "@theia/core" "1.23.0"
-    "@theia/editor" "1.23.0"
-    "@theia/filesystem" "1.23.0"
-    "@theia/markers" "1.23.0"
-    "@theia/monaco-editor-core" "0.23.0"
-    "@theia/outline-view" "1.23.0"
+    "@theia/core" "1.24.0"
+    "@theia/editor" "1.24.0"
+    "@theia/filesystem" "1.24.0"
+    "@theia/markers" "1.24.0"
+    "@theia/monaco-editor-core" "1.65.2"
+    "@theia/outline-view" "1.24.0"
     fast-plist "^0.1.2"
     idb "^4.0.5"
     jsonc-parser "^2.2.0"
     onigasm "^2.2.0"
     vscode-textmate "^4.4.0"
 
-"@theia/navigator@1.23.0", "@theia/navigator@^1.0.0":
-  version "1.23.0"
-  resolved "https://registry.yarnpkg.com/@theia/navigator/-/navigator-1.23.0.tgz#afdac7a43f4d17fa7c69df71f335cd2f0d7be4b7"
-  integrity sha512-w6gFdL9hItz1mqk35/pi112QmCpeZjHIaa3JKMWugQ2Ve23kVjwFt6X7IGTpYng+6UxRQ+xG3WQbCjfQJWkNuA==
+"@theia/navigator@1.24.0", "@theia/navigator@^1.24.0":
+  version "1.24.0"
+  resolved "https://registry.yarnpkg.com/@theia/navigator/-/navigator-1.24.0.tgz#c746f8ae4917647ce7b22dc5a54e90851634eb59"
+  integrity sha512-N9bhRUXyLIrxcArHeZHgcsv44ZFQXw9McTrAzVIZsZnTRkbWlWCCAkENF9lWUsPwfVvtfWCiiKstQIJCJsWk4g==
   dependencies:
-    "@theia/core" "1.23.0"
-    "@theia/filesystem" "1.23.0"
-    "@theia/workspace" "1.23.0"
+    "@theia/core" "1.24.0"
+    "@theia/filesystem" "1.24.0"
+    "@theia/workspace" "1.24.0"
     minimatch "^3.0.4"
 
-"@theia/outline-view@1.23.0":
-  version "1.23.0"
-  resolved "https://registry.yarnpkg.com/@theia/outline-view/-/outline-view-1.23.0.tgz#d39991d203c0edb914b11ed6a024920495b6a2bc"
-  integrity sha512-DmPnxlR93TjGakDULT62nuyrYhy9eKGPW/svydXXssHOz9/jMwf12PW8xHXT4YZdYKYzDrimgtz/5uTYngk+2A==
+"@theia/outline-view@1.24.0":
+  version "1.24.0"
+  resolved "https://registry.yarnpkg.com/@theia/outline-view/-/outline-view-1.24.0.tgz#a13d1efaa0d12c835acaa00779b57a627fb7b5a4"
+  integrity sha512-BDI1gk64UzEvW7eyB4imhGB1C6bITUDu9b47EEm8+rVL7LQ0JV2OwXIKU+yRX4XvaHF721pFNeiiEWaSmGzBLw==
   dependencies:
-    "@theia/core" "1.23.0"
+    "@theia/core" "1.24.0"
 
-"@theia/ovsx-client@1.23.0":
-  version "1.23.0"
-  resolved "https://registry.yarnpkg.com/@theia/ovsx-client/-/ovsx-client-1.23.0.tgz#6b51e002c757bb25a9ba1589199bb2836c3766de"
-  integrity sha512-uYqnkQHLtlguk0IAf1pUXWhlKUcTgpKF1HE5tQvguQ80o+UZ2wiEUCaMHsb+CSU7w9vDhAvqpR+GGppbexXEug==
+"@theia/ovsx-client@1.24.0":
+  version "1.24.0"
+  resolved "https://registry.yarnpkg.com/@theia/ovsx-client/-/ovsx-client-1.24.0.tgz#3aba9d929f7e0b5a2d46b51ead4e0f644c97bb1f"
+  integrity sha512-NZt8nmLiYVciiq1CLEm4mAyAxfiECsOs+OJknxMHjX5XW/yw8OuhUtF7Gva2FFX2N7sihdqcXHfWwYqQ3FYgWA==
   dependencies:
     "@types/bent" "^7.0.1"
     bent "^7.1.0"
     semver "^5.4.1"
 
-"@theia/preferences@^1.0.0":
-  version "1.23.0"
-  resolved "https://registry.yarnpkg.com/@theia/preferences/-/preferences-1.23.0.tgz#68cff53f70efeef764aa8c8c39630dd255f74954"
-  integrity sha512-zsmYZesB6LiYAvUQ2IQZVtvNEHM9v+AepEU2cGIVxsOwRNDPPJqraRuSjcsKYm2UI2zybELpZwewJlYio7Vmaw==
+"@theia/preferences@^1.24.0":
+  version "1.24.0"
+  resolved "https://registry.yarnpkg.com/@theia/preferences/-/preferences-1.24.0.tgz#1bd1e90190b7fbb0b86435691be9e4ce1416069e"
+  integrity sha512-qbB6K3clWTtOU5TPr89JHr7+lBbsyvWO2GyYWQJOifD34lg57k3bMuqe7To/0Li8m05xel4Bso1PI2c7IMb9wQ==
   dependencies:
-    "@theia/core" "1.23.0"
-    "@theia/editor" "1.23.0"
-    "@theia/filesystem" "1.23.0"
-    "@theia/monaco" "1.23.0"
-    "@theia/userstorage" "1.23.0"
-    "@theia/workspace" "1.23.0"
+    "@theia/core" "1.24.0"
+    "@theia/editor" "1.24.0"
+    "@theia/filesystem" "1.24.0"
+    "@theia/monaco" "1.24.0"
+    "@theia/monaco-editor-core" "1.65.2"
+    "@theia/userstorage" "1.24.0"
+    "@theia/workspace" "1.24.0"
     async-mutex "^0.3.1"
     jsonc-parser "^2.2.0"
     p-debounce "^2.1.0"
 
-"@theia/process@1.23.0", "@theia/process@^1.0.0":
-  version "1.23.0"
-  resolved "https://registry.yarnpkg.com/@theia/process/-/process-1.23.0.tgz#c0c01ee00a823119a3fddcc3251e6b6af5b596b0"
-  integrity sha512-LJt/uIDPKFMf5H00/YAABrqLxBEGfnKWpA1How95DjWCmT4A0dyXr2wQ3wszs3U7RAlJAPfGrm2U9eEs9bglPA==
+"@theia/process@1.24.0", "@theia/process@^1.24.0":
+  version "1.24.0"
+  resolved "https://registry.yarnpkg.com/@theia/process/-/process-1.24.0.tgz#40a54ee2c9e6ddb926de6693ee9299a00d268bff"
+  integrity sha512-dABEAniyBHryKSQCqwyocqbPBffhSdoEmkG3+ylLhiCFNiDjuT6FVwcZ31vR81AkSDfHynOUDnviMng4MJb5Xw==
   dependencies:
-    "@theia/core" "1.23.0"
+    "@theia/core" "1.24.0"
     node-pty "0.11.0-beta17"
     string-argv "^0.1.1"
 
-"@theia/terminal@^1.0.0":
-  version "1.23.0"
-  resolved "https://registry.yarnpkg.com/@theia/terminal/-/terminal-1.23.0.tgz#9eed3f1d4f416fd221489b91868d2f5a3b856852"
-  integrity sha512-KfOMKFR2uPQG2mi5neySZN2DKdHZTc+OKsR7F7URsbmigQMxwv2UYhViXyfc6JuzrBkpkiKRcNZpJ6Ae6nt/IQ==
+"@theia/terminal@^1.24.0":
+  version "1.24.0"
+  resolved "https://registry.yarnpkg.com/@theia/terminal/-/terminal-1.24.0.tgz#97eab958af012e87f60b46042f95bc97c94a4bf3"
+  integrity sha512-+vBEa+Cq53lFzSVAz7TRpmLiD9+wTTAd7M3FnW4VGU50LvE1LElaXlxT5gh6uLyXp4zW1CDjlkjE3oJk9uIdDw==
   dependencies:
-    "@theia/core" "1.23.0"
-    "@theia/editor" "1.23.0"
-    "@theia/filesystem" "1.23.0"
-    "@theia/process" "1.23.0"
-    "@theia/workspace" "1.23.0"
+    "@theia/core" "1.24.0"
+    "@theia/editor" "1.24.0"
+    "@theia/filesystem" "1.24.0"
+    "@theia/process" "1.24.0"
+    "@theia/workspace" "1.24.0"
     xterm "^4.16.0"
     xterm-addon-fit "^0.5.0"
     xterm-addon-search "^0.8.2"
 
-"@theia/userstorage@1.23.0":
-  version "1.23.0"
-  resolved "https://registry.yarnpkg.com/@theia/userstorage/-/userstorage-1.23.0.tgz#45da6035debb724c688db6af321a5f1a4a1324f0"
-  integrity sha512-0FDTYuJwYYCgvfQErLJWtyNGCId+HfYAo0mzCeNaBgkuyPLNpu1yQjBYTluX9cPVr95aXP58nNBFsijLAaZO2w==
+"@theia/userstorage@1.24.0":
+  version "1.24.0"
+  resolved "https://registry.yarnpkg.com/@theia/userstorage/-/userstorage-1.24.0.tgz#36d4d93b66acde7a7c9febdd815d5711cfafb6f0"
+  integrity sha512-Su1eX03VvkVaFztx7hVYx2jYhjQACklDf0nN/hxm9+7iRWbsmhXmngXtdvVK7ojBXt4AZ2NfPy1QwneMOACuNg==
   dependencies:
-    "@theia/core" "1.23.0"
-    "@theia/filesystem" "1.23.0"
+    "@theia/core" "1.24.0"
+    "@theia/filesystem" "1.24.0"
 
-"@theia/variable-resolver@1.23.0":
-  version "1.23.0"
-  resolved "https://registry.yarnpkg.com/@theia/variable-resolver/-/variable-resolver-1.23.0.tgz#6470521f66306432daf632cedc61d1ea681673d6"
-  integrity sha512-rcFIfwvGM46WbytAPOMdPm+bG4mpSFXOBDnE232kgJyMRKzROVwG5b2k8HVr22jp7302KMY/b8wWP04aNgYYAw==
+"@theia/variable-resolver@1.24.0":
+  version "1.24.0"
+  resolved "https://registry.yarnpkg.com/@theia/variable-resolver/-/variable-resolver-1.24.0.tgz#2a13d431fd584b69f013e3b8b263a35a362bd126"
+  integrity sha512-vdIE0JO0lgxe7BaM0G0ZjbdewaM5DzKLe9AlA02Jf9ONmpq+QKvqhJmq0BFtRBPsTZtG4H4t9pCqwhrmyqR1Ig==
   dependencies:
-    "@theia/core" "1.23.0"
+    "@theia/core" "1.24.0"
 
-"@theia/workspace@1.23.0", "@theia/workspace@^1.0.0":
-  version "1.23.0"
-  resolved "https://registry.yarnpkg.com/@theia/workspace/-/workspace-1.23.0.tgz#a93f2d6e68d9a519603c2adc2ef550414be54035"
-  integrity sha512-EAY6DEaQ8qERfe5wr5YZ4ZazSS9J/PxV4/oagDG2yWg5VUrsDLOoX2crp2ZT716PVFmorK1eTLR2rt9xQQ7keQ==
+"@theia/workspace@1.24.0", "@theia/workspace@^1.24.0":
+  version "1.24.0"
+  resolved "https://registry.yarnpkg.com/@theia/workspace/-/workspace-1.24.0.tgz#68964267b61302193268b8911e9d436044265551"
+  integrity sha512-SDN+dDEoUprsjiQAUfDQhHghtKKMUhvIM0f8zf9n31zQNCmWKndKO1RZR1HuQ8oX/V+i9mWYt0PJ2TeQv5JOtA==
   dependencies:
-    "@theia/core" "1.23.0"
-    "@theia/filesystem" "1.23.0"
-    "@theia/variable-resolver" "1.23.0"
+    "@theia/core" "1.24.0"
+    "@theia/filesystem" "1.24.0"
+    "@theia/variable-resolver" "1.24.0"
     jsonc-parser "^2.2.0"
     valid-filename "^2.0.1"
 
@@ -2629,6 +2622,11 @@
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz#0ea7b61496902b95890dc4c3a116b60cb8dae812"
   integrity sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ==
+
+"@types/json-buffer@~3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/json-buffer/-/json-buffer-3.0.0.tgz#85c1ff0f0948fc159810d4b5be35bf8c20875f64"
+  integrity sha512-3YP80IxxFJB4b5tYC2SUPwkg0XQLiu0nWvhRgEatgjf+29IcWO9X1k8xRv5DGssJ/lCrjYTjQPcobJr2yWIVuQ==
 
 "@types/json-schema@*", "@types/json-schema@^7.0.5", "@types/json-schema@^7.0.8", "@types/json-schema@^7.0.9":
   version "7.0.11"
@@ -2932,13 +2930,13 @@
     "@types/yargs-parser" "*"
 
 "@typescript-eslint/eslint-plugin@^5.13.0":
-  version "5.17.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.17.0.tgz#704eb4e75039000531255672bf1c85ee85cf1d67"
-  integrity sha512-qVstvQilEd89HJk3qcbKt/zZrfBZ+9h2ynpAGlWjWiizA7m/MtLT9RoX6gjtpE500vfIg8jogAkDzdCxbsFASQ==
+  version "5.18.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.18.0.tgz#950df411cec65f90d75d6320a03b2c98f6c3af7d"
+  integrity sha512-tzrmdGMJI/uii9/V6lurMo4/o+dMTKDH82LkNjhJ3adCW22YQydoRs5MwTiqxGF9CSYxPxQ7EYb4jLNlIs+E+A==
   dependencies:
-    "@typescript-eslint/scope-manager" "5.17.0"
-    "@typescript-eslint/type-utils" "5.17.0"
-    "@typescript-eslint/utils" "5.17.0"
+    "@typescript-eslint/scope-manager" "5.18.0"
+    "@typescript-eslint/type-utils" "5.18.0"
+    "@typescript-eslint/utils" "5.18.0"
     debug "^4.3.2"
     functional-red-black-tree "^1.0.1"
     ignore "^5.1.8"
@@ -2947,75 +2945,75 @@
     tsutils "^3.21.0"
 
 "@typescript-eslint/experimental-utils@^5.0.0":
-  version "5.17.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-5.17.0.tgz#303ba1d766d715c3225a31845b54941889e52f6c"
-  integrity sha512-U4sM5z0/ymSYqQT6I7lz8l0ZZ9zrya5VIwrwAP5WOJVabVtVsIpTMxPQe+D3qLyePT+VlETUTO2nA1+PufPx9Q==
+  version "5.18.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-5.18.0.tgz#a6b5662e6b0452cb0e75a13662ce3b33cd1be59d"
+  integrity sha512-hypiw5N0aM2aH91/uMmG7RpyUH3PN/iOhilMwkMFZIbm/Bn/G3ZnbaYdSoAN4PG/XHQjdhBYLi0ZoRZsRYT4hA==
   dependencies:
-    "@typescript-eslint/utils" "5.17.0"
+    "@typescript-eslint/utils" "5.18.0"
 
 "@typescript-eslint/parser@^5.13.0":
-  version "5.17.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.17.0.tgz#7def77d5bcd8458d12d52909118cf3f0a45f89d5"
-  integrity sha512-aRzW9Jg5Rlj2t2/crzhA2f23SIYFlF9mchGudyP0uiD6SenIxzKoLjwzHbafgHn39dNV/TV7xwQkLfFTZlJ4ig==
+  version "5.18.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.18.0.tgz#2bcd4ff21df33621df33e942ccb21cb897f004c6"
+  integrity sha512-+08nYfurBzSSPndngnHvFw/fniWYJ5ymOrn/63oMIbgomVQOvIDhBoJmYZ9lwQOCnQV9xHGvf88ze3jFGUYooQ==
   dependencies:
-    "@typescript-eslint/scope-manager" "5.17.0"
-    "@typescript-eslint/types" "5.17.0"
-    "@typescript-eslint/typescript-estree" "5.17.0"
+    "@typescript-eslint/scope-manager" "5.18.0"
+    "@typescript-eslint/types" "5.18.0"
+    "@typescript-eslint/typescript-estree" "5.18.0"
     debug "^4.3.2"
 
-"@typescript-eslint/scope-manager@5.17.0":
-  version "5.17.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.17.0.tgz#4cea7d0e0bc0e79eb60cad431c89120987c3f952"
-  integrity sha512-062iCYQF/doQ9T2WWfJohQKKN1zmmXVfAcS3xaiialiw8ZUGy05Em6QVNYJGO34/sU1a7a+90U3dUNfqUDHr3w==
+"@typescript-eslint/scope-manager@5.18.0":
+  version "5.18.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.18.0.tgz#a7d7b49b973ba8cebf2a3710eefd457ef2fb5505"
+  integrity sha512-C0CZML6NyRDj+ZbMqh9FnPscg2PrzSaVQg3IpTmpe0NURMVBXlghGZgMYqBw07YW73i0MCqSDqv2SbywnCS8jQ==
   dependencies:
-    "@typescript-eslint/types" "5.17.0"
-    "@typescript-eslint/visitor-keys" "5.17.0"
+    "@typescript-eslint/types" "5.18.0"
+    "@typescript-eslint/visitor-keys" "5.18.0"
 
-"@typescript-eslint/type-utils@5.17.0":
-  version "5.17.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.17.0.tgz#1c4549d68c89877662224aabb29fbbebf5fc9672"
-  integrity sha512-3hU0RynUIlEuqMJA7dragb0/75gZmwNwFf/QJokWzPehTZousP/MNifVSgjxNcDCkM5HI2K22TjQWUmmHUINSg==
+"@typescript-eslint/type-utils@5.18.0":
+  version "5.18.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.18.0.tgz#62dbfc8478abf36ba94a90ddf10be3cc8e471c74"
+  integrity sha512-vcn9/6J5D6jtHxpEJrgK8FhaM8r6J1/ZiNu70ZUJN554Y3D9t3iovi6u7JF8l/e7FcBIxeuTEidZDR70UuCIfA==
   dependencies:
-    "@typescript-eslint/utils" "5.17.0"
+    "@typescript-eslint/utils" "5.18.0"
     debug "^4.3.2"
     tsutils "^3.21.0"
 
-"@typescript-eslint/types@5.17.0":
-  version "5.17.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.17.0.tgz#861ec9e669ffa2aa9b873dd4d28d9b1ce26d216f"
-  integrity sha512-AgQ4rWzmCxOZLioFEjlzOI3Ch8giDWx8aUDxyNw9iOeCvD3GEYAB7dxWGQy4T/rPVe8iPmu73jPHuaSqcjKvxw==
+"@typescript-eslint/types@5.18.0":
+  version "5.18.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.18.0.tgz#4f0425d85fdb863071680983853c59a62ce9566e"
+  integrity sha512-bhV1+XjM+9bHMTmXi46p1Led5NP6iqQcsOxgx7fvk6gGiV48c6IynY0apQb7693twJDsXiVzNXTflhplmaiJaw==
 
-"@typescript-eslint/typescript-estree@5.17.0":
-  version "5.17.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.17.0.tgz#a7cba7dfc8f9cc2ac78c18584e684507df4f2488"
-  integrity sha512-X1gtjEcmM7Je+qJRhq7ZAAaNXYhTgqMkR10euC4Si6PIjb+kwEQHSxGazXUQXFyqfEXdkGf6JijUu5R0uceQzg==
+"@typescript-eslint/typescript-estree@5.18.0":
+  version "5.18.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.18.0.tgz#6498e5ee69a32e82b6e18689e2f72e4060986474"
+  integrity sha512-wa+2VAhOPpZs1bVij9e5gyVu60ReMi/KuOx4LKjGx2Y3XTNUDJgQ+5f77D49pHtqef/klglf+mibuHs9TrPxdQ==
   dependencies:
-    "@typescript-eslint/types" "5.17.0"
-    "@typescript-eslint/visitor-keys" "5.17.0"
+    "@typescript-eslint/types" "5.18.0"
+    "@typescript-eslint/visitor-keys" "5.18.0"
     debug "^4.3.2"
     globby "^11.0.4"
     is-glob "^4.0.3"
     semver "^7.3.5"
     tsutils "^3.21.0"
 
-"@typescript-eslint/utils@5.17.0":
-  version "5.17.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.17.0.tgz#549a9e1d491c6ccd3624bc3c1b098f5cfb45f306"
-  integrity sha512-DVvndq1QoxQH+hFv+MUQHrrWZ7gQ5KcJzyjhzcqB1Y2Xes1UQQkTRPUfRpqhS8mhTWsSb2+iyvDW1Lef5DD7vA==
+"@typescript-eslint/utils@5.18.0":
+  version "5.18.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.18.0.tgz#27fc84cf95c1a96def0aae31684cb43a37e76855"
+  integrity sha512-+hFGWUMMri7OFY26TsOlGa+zgjEy1ssEipxpLjtl4wSll8zy85x0GrUSju/FHdKfVorZPYJLkF3I4XPtnCTewA==
   dependencies:
     "@types/json-schema" "^7.0.9"
-    "@typescript-eslint/scope-manager" "5.17.0"
-    "@typescript-eslint/types" "5.17.0"
-    "@typescript-eslint/typescript-estree" "5.17.0"
+    "@typescript-eslint/scope-manager" "5.18.0"
+    "@typescript-eslint/types" "5.18.0"
+    "@typescript-eslint/typescript-estree" "5.18.0"
     eslint-scope "^5.1.1"
     eslint-utils "^3.0.0"
 
-"@typescript-eslint/visitor-keys@5.17.0":
-  version "5.17.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.17.0.tgz#52daae45c61b0211b4c81b53a71841911e479128"
-  integrity sha512-6K/zlc4OfCagUu7Am/BD5k8PSWQOgh34Nrv9Rxe2tBzlJ7uOeJ/h7ugCGDCeEZHT6k2CJBhbk9IsbkPI0uvUkA==
+"@typescript-eslint/visitor-keys@5.18.0":
+  version "5.18.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.18.0.tgz#c7c07709823804171d569017f3b031ced7253e60"
+  integrity sha512-Hf+t+dJsjAKpKSkg3EHvbtEpFFb/1CiOHnvI8bjHgOD4/wAw3gKrA0i94LrbekypiZVanJu3McWJg7rWDMzRTg==
   dependencies:
-    "@typescript-eslint/types" "5.17.0"
+    "@typescript-eslint/types" "5.18.0"
     eslint-visitor-keys "^3.0.0"
 
 "@ungap/promise-all-settled@1.1.2":
@@ -3697,7 +3695,7 @@ bluebird@~3.4.1:
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.4.7.tgz#f72d760be09b7f76d08ed8fae98b289a8d05fab3"
   integrity sha1-9y12C+Cbf3bQjtj66Ysomo0F+rM=
 
-body-parser@1.19.2, body-parser@^1.17.2, body-parser@^1.18.3:
+body-parser@1.19.2:
   version "1.19.2"
   resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.19.2.tgz#4714ccd9c157d44797b8b5607d72c0b89952f26e"
   integrity sha512-SAAwOxgoCKMGs9uUAUFHygfLAyaniaoun6I8mFY9pRAJL9+Kec34aU+oIjDhTycub1jozEfEwx1W1IuOYxVSFw==
@@ -3712,6 +3710,24 @@ body-parser@1.19.2, body-parser@^1.17.2, body-parser@^1.18.3:
     qs "6.9.7"
     raw-body "2.4.3"
     type-is "~1.6.18"
+
+body-parser@^1.17.2, body-parser@^1.18.3:
+  version "1.20.0"
+  resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.20.0.tgz#3de69bd89011c11573d7bfee6a64f11b6bd27cc5"
+  integrity sha512-DfJ+q6EPcGKZD1QWUjSpqp+Q7bDQTsQIF4zfUAtZ6qk+H/3/QRhg9CEp39ss+/T2vw0+HaidC0ecJj/DRLIaKg==
+  dependencies:
+    bytes "3.1.2"
+    content-type "~1.0.4"
+    debug "2.6.9"
+    depd "2.0.0"
+    destroy "1.2.0"
+    http-errors "2.0.0"
+    iconv-lite "0.4.24"
+    on-finished "2.4.1"
+    qs "6.10.3"
+    raw-body "2.5.1"
+    type-is "~1.6.18"
+    unpipe "1.0.0"
 
 boolean@^3.0.1:
   version "3.2.0"
@@ -3924,9 +3940,9 @@ camelcase@^6.0.0:
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
 caniuse-lite@^1.0.30001317:
-  version "1.0.30001322"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001322.tgz#2e4c09d11e1e8f852767dab287069a8d0c29d623"
-  integrity sha512-neRmrmIrCGuMnxGSoh+x7zYtQFFgnSY2jaomjU56sCkTA6JINqQrxutF459JpWcWRajvoyn95sOXq4Pqrnyjew==
+  version "1.0.30001325"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001325.tgz#2b4ad19b77aa36f61f2eaf72e636d7481d55e606"
+  integrity sha512-sB1bZHjseSjDtijV1Hb7PB2Zd58Kyx+n/9EotvZ4Qcz2K3d0lWB8dB4nb8wN/TsOGFq3UuAm0zQZNQ4SoR7TrQ==
 
 caseless@~0.12.0:
   version "0.12.0"
@@ -4211,6 +4227,14 @@ component-emitter@~1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"
   integrity sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==
+
+compress-brotli@^1.3.6:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/compress-brotli/-/compress-brotli-1.3.6.tgz#64bd6f21f4f3e9841dbac392f4c29218caf5e9d9"
+  integrity sha512-au99/GqZtUtiCBliqLFbWlhnCxn+XSYjwZ77q6mKN4La4qOXDoLVPZ50iXr0WmAyMxl8yqoq3Yq4OeQNPPkyeQ==
+  dependencies:
+    "@types/json-buffer" "~3.0.0"
+    json-buffer "~3.0.1"
 
 compression-webpack-plugin@^9.0.0:
   version "9.2.0"
@@ -4698,6 +4722,11 @@ delegates@^1.0.0:
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
   integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
 
+depd@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/depd/-/depd-2.0.0.tgz#b696163cc757560d09cf22cc8fad1571b79e76df"
+  integrity sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==
+
 depd@^1.1.2, depd@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
@@ -4707,6 +4736,11 @@ deprecation@^2.0.0, deprecation@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/deprecation/-/deprecation-2.3.1.tgz#6368cbdb40abf3373b525ac87e4a260c3a700919"
   integrity sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==
+
+destroy@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.2.0.tgz#4803735509ad8be552934c67df614f94e66fa015"
+  integrity sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==
 
 destroy@~1.0.4:
   version "1.0.4"
@@ -4734,9 +4768,9 @@ detect-node@^2.0.4:
   integrity sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==
 
 dezalgo@^1.0.0:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/dezalgo/-/dezalgo-1.0.3.tgz#7f742de066fc748bc8db820569dddce49bf0d456"
-  integrity sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/dezalgo/-/dezalgo-1.0.4.tgz#751235260469084c132157dfa857f386d4c33d81"
+  integrity sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==
   dependencies:
     asap "^2.0.0"
     wrappy "1"
@@ -4885,9 +4919,9 @@ electron-rebuild@^3.2.7:
     yargs "^17.0.1"
 
 electron-to-chromium@^1.4.84:
-  version "1.4.101"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.101.tgz#71f3a10065146d7445ba5d4c06ba2cc063b0817a"
-  integrity sha512-XJH+XmJjACx1S7ASl/b//KePcda5ocPnFH2jErztXcIS8LpP0SE6rX8ZxiY5/RaDPnaF1rj0fPaHfppzb0e2Aw==
+  version "1.4.106"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.106.tgz#e7a3bfa9d745dd9b9e597616cb17283cc349781a"
+  integrity sha512-ZYfpVLULm67K7CaaGP7DmjyeMY4naxsbTy+syVVxT6QHI1Ww8XbJjmr9fDckrhq44WzCrcC5kH3zGpdusxwwqg==
 
 emoji-regex@^7.0.1:
   version "7.0.3"
@@ -5086,7 +5120,7 @@ eslint-import-resolver-node@^0.3.6:
     debug "^3.2.7"
     resolve "^1.20.0"
 
-eslint-module-utils@^2.7.2:
+eslint-module-utils@^2.7.3:
   version "2.7.3"
   resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.7.3.tgz#ad7e3a10552fdd0642e1e55292781bd6e34876ee"
   integrity sha512-088JEC7O3lDZM9xGe0RerkOMd0EjFl+Yvd1jPWIkMT5u3H9+HC34mWWPnqPrN13gieT9pBOO+Qt07Nb/6TresQ==
@@ -5114,23 +5148,23 @@ eslint-plugin-header@^3.1.1:
   integrity sha512-9vlKxuJ4qf793CmeeSrZUvVClw6amtpghq3CuWcB5cUNnWHQhgcqy5eF8oVKFk1G3Y/CbchGfEaw3wiIJaNmVg==
 
 eslint-plugin-import@^2.25.4:
-  version "2.25.4"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.25.4.tgz#322f3f916a4e9e991ac7af32032c25ce313209f1"
-  integrity sha512-/KJBASVFxpu0xg1kIBn9AUa8hQVnszpwgE7Ld0lKAlx7Ie87yzEzCgSkekt+le/YVhiaosO4Y14GDAOc41nfxA==
+  version "2.26.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.26.0.tgz#f812dc47be4f2b72b478a021605a59fc6fe8b88b"
+  integrity sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==
   dependencies:
     array-includes "^3.1.4"
     array.prototype.flat "^1.2.5"
     debug "^2.6.9"
     doctrine "^2.1.0"
     eslint-import-resolver-node "^0.3.6"
-    eslint-module-utils "^2.7.2"
+    eslint-module-utils "^2.7.3"
     has "^1.0.3"
-    is-core-module "^2.8.0"
+    is-core-module "^2.8.1"
     is-glob "^4.0.3"
-    minimatch "^3.0.4"
+    minimatch "^3.1.2"
     object.values "^1.1.5"
-    resolve "^1.20.0"
-    tsconfig-paths "^3.12.0"
+    resolve "^1.22.0"
+    tsconfig-paths "^3.14.1"
 
 eslint-plugin-no-null@^1.0.2:
   version "1.0.2"
@@ -6017,9 +6051,9 @@ got@^9.6.0:
     url-parse-lax "^3.0.0"
 
 graceful-fs@^4.1.10, graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.2, graceful-fs@^4.2.3, graceful-fs@^4.2.4, graceful-fs@^4.2.6, graceful-fs@^4.2.9:
-  version "4.2.9"
-  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.9.tgz#041b05df45755e587a24942279b9d113146e1c96"
-  integrity sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==
+  version "4.2.10"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.10.tgz#147d3a006da4ca3ce14728c7aefc287c367d7a6c"
+  integrity sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==
 
 growl@1.10.5:
   version "1.10.5"
@@ -6131,6 +6165,17 @@ http-errors@1.8.1:
     inherits "2.0.4"
     setprototypeof "1.2.0"
     statuses ">= 1.5.0 < 2"
+    toidentifier "1.0.1"
+
+http-errors@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-2.0.0.tgz#b7774a1486ef73cf7667ac9ae0858c012c57b9d3"
+  integrity sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==
+  dependencies:
+    depd "2.0.0"
+    inherits "2.0.4"
+    setprototypeof "1.2.0"
+    statuses "2.0.1"
     toidentifier "1.0.1"
 
 http-proxy-agent@^4.0.1:
@@ -6407,7 +6452,7 @@ is-ci@^2.0.0:
   dependencies:
     ci-info "^2.0.0"
 
-is-core-module@^2.5.0, is-core-module@^2.8.0, is-core-module@^2.8.1:
+is-core-module@^2.5.0, is-core-module@^2.8.1:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.8.1.tgz#f59fdfca701d5879d0a6b100a40aa1560ce27211"
   integrity sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==
@@ -6476,9 +6521,9 @@ is-negative-zero@^2.0.2:
   integrity sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==
 
 is-number-object@^1.0.4:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/is-number-object/-/is-number-object-1.0.6.tgz#6a7aaf838c7f0686a50b4553f7e54a96494e89f0"
-  integrity sha512-bEVOqiRcvo3zO1+G2lVMy+gkkEm9Yh7cDMRusKKu5ZJKPUYSJwICTKZrNKHA2EbSP0Tu0+6B/emsYNHZyn6K8g==
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/is-number-object/-/is-number-object-1.0.7.tgz#59d50ada4c45251784e9904f5246c742f07a42fc"
+  integrity sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==
   dependencies:
     has-tostringtag "^1.0.0"
 
@@ -6533,9 +6578,11 @@ is-regex@^1.1.4:
     has-tostringtag "^1.0.0"
 
 is-shared-array-buffer@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-shared-array-buffer/-/is-shared-array-buffer-1.0.1.tgz#97b0c85fbdacb59c9c446fe653b82cf2b5b7cfe6"
-  integrity sha512-IU0NmyknYZN0rChcKhRO1X8LYz5Isj/Fsqh8NJOSf+N/hCOTwy29F32Ik7a+QszE63IdvmwdTPDd6cZ5pg4cwA==
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz#8f259c573b60b6a32d4058a1a07430c0a7344c79"
+  integrity sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==
+  dependencies:
+    call-bind "^1.0.2"
 
 is-ssh@^1.3.0:
   version "1.3.3"
@@ -6676,7 +6723,7 @@ json-buffer@3.0.0:
   resolved "https://registry.yarnpkg.com/json-buffer/-/json-buffer-3.0.0.tgz#5b1f397afc75d677bde8bcfc0e47e1f9a3d9a898"
   integrity sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=
 
-json-buffer@3.0.1:
+json-buffer@3.0.1, json-buffer@~3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/json-buffer/-/json-buffer-3.0.1.tgz#9338802a30d3b6605fbe0613e094008ca8c05a13"
   integrity sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==
@@ -6723,7 +6770,7 @@ json5@^1.0.1:
   dependencies:
     minimist "^1.2.0"
 
-json5@^2.1.2:
+json5@^2.1.2, json5@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.1.tgz#655d50ed1e6f95ad1a3caababd2b0efda10b395c"
   integrity sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==
@@ -6785,10 +6832,11 @@ keyv@^3.0.0:
     json-buffer "3.0.0"
 
 keyv@^4.0.0:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/keyv/-/keyv-4.1.1.tgz#02c538bfdbd2a9308cc932d4096f05ae42bfa06a"
-  integrity sha512-tGv1yP6snQVDSM4X6yxrv2zzq/EvpW+oYiUz6aueW1u9CtS8RzUQYxxmFwgZlO2jSgCxQbchhxaqXXp2hnKGpQ==
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/keyv/-/keyv-4.2.2.tgz#4b6f602c0228ef4d8214c03c520bef469ed6b768"
+  integrity sha512-uYS0vKTlBIjNCAUqrjlxmruxOEiZxZIHXyp32sdcGmP+ukFrmWUnE//RcPXJH3Vxrni1H2gsQbjHE0bH7MtMQQ==
   dependencies:
+    compress-brotli "^1.3.6"
     json-buffer "3.0.1"
 
 kind-of@^6.0.2, kind-of@^6.0.3:
@@ -7066,6 +7114,11 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
+lru-cache@^7.4.0:
+  version "7.7.3"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-7.7.3.tgz#98cd19eef89ce6a4a3c4502c17c833888677c252"
+  integrity sha512-WY9wjJNQt9+PZilnLbuFKM+SwDull9+6IAguOrarOMoOHTcJ9GnXSO11+Gw6c7xtDkBkthR57OZMtZKYr+1CEw==
+
 lzma-native@^8.0.5:
   version "8.0.6"
   resolved "https://registry.yarnpkg.com/lzma-native/-/lzma-native-8.0.6.tgz#3ea456209d643bafd9b5d911781bdf0b396b2665"
@@ -7289,7 +7342,7 @@ minimatch@4.2.1:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimatch@^3.0.4:
+minimatch@^3.0.4, minimatch@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
   integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
@@ -7705,9 +7758,9 @@ node-fetch@^2.6.0, node-fetch@^2.6.1, node-fetch@^2.6.7:
     whatwg-url "^5.0.0"
 
 node-gyp-build@^4.2.1:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.3.0.tgz#9f256b03e5826150be39c764bf51e993946d71a3"
-  integrity sha512-iWjXZvmboq0ja1pUGULQBexmxq8CV4xBhX7VDOTbL7ZR4FOowwY/VOtRxBN/yKxmdGoIp4j5ysNT4u3S2pDQ3Q==
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.4.0.tgz#42e99687ce87ddeaf3a10b99dc06abc11021f3f4"
+  integrity sha512-amJnQCcgtRVw9SvoebO3BKGESClrfXGCUTX9hSn1OuGQTQBOZmVd0Z0OlecpuRksKvbsUqALE8jls/ErClAPuQ==
 
 node-gyp@^5.0.2:
   version "5.1.1"
@@ -8025,7 +8078,7 @@ object.values@^1.1.5:
     define-properties "^1.1.3"
     es-abstract "^1.19.1"
 
-on-finished@^2.3.0:
+on-finished@2.4.1, on-finished@^2.3.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/on-finished/-/on-finished-2.4.1.tgz#58c8c44116e54845ad57f14ab10b03533184ac3f"
   integrity sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==
@@ -8484,9 +8537,9 @@ postcss-modules-values@^4.0.0:
     icss-utils "^5.0.0"
 
 postcss-selector-parser@^6.0.2, postcss-selector-parser@^6.0.4:
-  version "6.0.9"
-  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.9.tgz#ee71c3b9ff63d9cd130838876c13a2ec1a992b2f"
-  integrity sha512-UO3SgnZOVTwu4kyLR22UQ1xZh086RyNZppb7lLAKBFK8a32ttG5i87Y/P3+2bRSjZNyJ1B7hfFNo273tKe9YxQ==
+  version "6.0.10"
+  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz#79b61e2c0d1bfc2602d549e11d0876256f8df88d"
+  integrity sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==
   dependencies:
     cssesc "^3.0.0"
     util-deprecate "^1.0.2"
@@ -8556,9 +8609,9 @@ prepend-http@^2.0.0:
   integrity sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=
 
 prettier@^2.4.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.6.1.tgz#d472797e0d7461605c1609808e27b80c0f9cfe17"
-  integrity sha512-8UVbTBYGwN37Bs9LERmxCPjdvPxlEowx2urIL6urHzdb3SDq4B/Z6xLFCblrSnE4iKWcS6ziJ3aOYrc1kz/E2A==
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.6.2.tgz#e26d71a18a74c3d0f0597f55f01fb6c06c206032"
+  integrity sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==
 
 private@~0.1.5:
   version "0.1.8"
@@ -8694,17 +8747,17 @@ q@^1.5.1:
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
   integrity sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=
 
-qs@6.9.7:
-  version "6.9.7"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.9.7.tgz#4610846871485e1e048f44ae3b94033f0e675afe"
-  integrity sha512-IhMFgUmuNpyRfxA90umL7ByLlgRXu6tIfKPpF5TmcfRLlLCckfP/g3IQmju6jjpu+Hh8rA+2p6A27ZSPOOHdKw==
-
-qs@^6.9.4:
+qs@6.10.3, qs@^6.9.4:
   version "6.10.3"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.10.3.tgz#d6cde1b2ffca87b5aa57889816c5f81535e22e8e"
   integrity sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==
   dependencies:
     side-channel "^1.0.4"
+
+qs@6.9.7:
+  version "6.9.7"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.9.7.tgz#4610846871485e1e048f44ae3b94033f0e675afe"
+  integrity sha512-IhMFgUmuNpyRfxA90umL7ByLlgRXu6tIfKPpF5TmcfRLlLCckfP/g3IQmju6jjpu+Hh8rA+2p6A27ZSPOOHdKw==
 
 qs@~6.5.2:
   version "6.5.3"
@@ -8755,6 +8808,16 @@ raw-body@2.4.3:
   dependencies:
     bytes "3.1.2"
     http-errors "1.8.1"
+    iconv-lite "0.4.24"
+    unpipe "1.0.0"
+
+raw-body@2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.5.1.tgz#fe1b1628b181b700215e5fd42389f98b71392857"
+  integrity sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==
+  dependencies:
+    bytes "3.1.2"
+    http-errors "2.0.0"
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
@@ -9028,10 +9091,10 @@ regenerator-runtime@^0.13.4:
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz#8925742a98ffd90814988d7566ad30ca3b263b52"
   integrity sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==
 
-regenerator-transform@^0.14.2:
-  version "0.14.5"
-  resolved "https://registry.yarnpkg.com/regenerator-transform/-/regenerator-transform-0.14.5.tgz#c98da154683671c9c4dcb16ece736517e1b7feb4"
-  integrity sha512-eOf6vka5IO151Jfsw2NO9WpGX58W6wWmefK3I1zEGr0lOD0u8rwPaNqQL1aRxUaxLeKO3ArNh3VYg1KbaD+FFw==
+regenerator-transform@^0.15.0:
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/regenerator-transform/-/regenerator-transform-0.15.0.tgz#cbd9ead5d77fae1a48d957cf889ad0586adb6537"
+  integrity sha512-LsrGtPmbYg19bcPHwdtmXwbW+TqNvtY4riE3P83foeHRroMbH6/2ddFBfab3t7kbzc7v7p4wbkIecHImqt0QNg==
   dependencies:
     "@babel/runtime" "^7.8.4"
 
@@ -9127,7 +9190,7 @@ resolve-from@^5.0.0:
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-5.0.0.tgz#c35225843df8f776df21c57557bc087e9dfdfc69"
   integrity sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==
 
-resolve@^1.10.0, resolve@^1.14.2, resolve@^1.20.0, resolve@^1.9.0:
+resolve@^1.10.0, resolve@^1.14.2, resolve@^1.20.0, resolve@^1.22.0, resolve@^1.9.0:
   version "1.22.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.0.tgz#5e0b8c67c15df57a89bdbabe603a002f21731198"
   integrity sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==
@@ -9309,11 +9372,11 @@ semver@^6.0.0, semver@^6.1.1, semver@^6.1.2, semver@^6.2.0, semver@^6.3.0:
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
 semver@^7.1.1, semver@^7.1.3, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5:
-  version "7.3.5"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
-  integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
+  version "7.3.6"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.6.tgz#5d73886fb9c0c6602e79440b97165c29581cbb2b"
+  integrity sha512-HZWqcgwLsjaX1HBD31msI/rXktuIhS+lWvdE4kN9z+8IVT4Itc7vqU2WvYsyD6/sjYCt4dEKH/m1M3dwI9CC5w==
   dependencies:
-    lru-cache "^6.0.0"
+    lru-cache "^7.4.0"
 
 send@0.17.2:
   version "0.17.2"
@@ -9698,6 +9761,11 @@ ssri@^8.0.0, ssri@^8.0.1:
   integrity sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==
   dependencies:
     minipass "^3.1.1"
+
+statuses@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/statuses/-/statuses-2.0.1.tgz#55cb000ccf1d48728bd23c685a063998cf1a1b63"
+  integrity sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==
 
 "statuses@>= 1.5.0 < 2", statuses@~1.5.0:
   version "1.5.0"
@@ -10184,7 +10252,7 @@ ts-node@^10.4.0:
     v8-compile-cache-lib "^3.0.0"
     yn "3.1.1"
 
-tsconfig-paths@^3.12.0:
+tsconfig-paths@^3.14.1:
   version "3.14.1"
   resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz#ba0734599e8ea36c862798e920bcf163277b137a"
   integrity sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==
@@ -10628,9 +10696,9 @@ webpack-sources@^3.2.3:
   integrity sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==
 
 webpack@^5.48.0:
-  version "5.70.0"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.70.0.tgz#3461e6287a72b5e6e2f4872700bc8de0d7500e6d"
-  integrity sha512-ZMWWy8CeuTTjCxbeaQI21xSswseF2oNOwc70QSKNePvmxE7XW36i7vpBMYZFAUHPwQiEbNGCEYIOOlyRbdGmxw==
+  version "5.71.0"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.71.0.tgz#b01fcf379570b8c5ee06ca06c829ca168c951884"
+  integrity sha512-g4dFT7CFG8LY0iU5G8nBL6VlkT21Z7dcYDpJAEJV5Q1WLb9UwnFbrem1k7K52ILqEmomN7pnzWFxxE6SlDY56A==
   dependencies:
     "@types/eslint-scope" "^3.7.3"
     "@types/estree" "^0.0.51"


### PR DESCRIPTION
- Adapt the code base to conform to client changes introduced with https://github.com/eclipse-glsp/glsp-client/pull/176
- Update to Theia 1.24.0. This introduces an API break in the `Saveable API`. As a consequence the Depdency ranges have been adapted
from `^1.0.0` to `^1.24.0`.

- Update launch configs:
-- Replace the (Debug) suffix with (External GLSP Server) to make the intended use of this config more clear.
-- Introduce compound configs to launch both frontend and backend in debug mode.

Requires https://github.com/eclipse-glsp/glsp-client/pull/176
Part of eclipse-glsp/glsp/issues/609