### PR TITLE
GH-650 Fix reload after SourceModel Change

### DIFF
--- a/packages/theia-integration/src/browser/diagram/glsp-diagram-widget.ts
+++ b/packages/theia-integration/src/browser/diagram/glsp-diagram-widget.ts
@@ -147,7 +147,7 @@ export class GLSPDiagramWidget extends DiagramWidget implements SaveableSource {
     }
 
     reloadModel(): Promise<void> {
-        return this.actionDispatcher.dispatch(RequestModelAction.create(this.requestModelOptions));
+        return this.actionDispatcher.dispatch(RequestModelAction.create({ options: this.requestModelOptions }));
     }
 
     handleMouseEnter(e: MouseEvent): void {


### PR DESCRIPTION
Ensure that `GlspDiagramWidget.reloadModel` dispatches a valid `RequestModelAction`

Fixes https://github.com/eclipse-glsp/glsp/issues/650