### PR TITLE
GH-636 Refactor JavaSocketServerContribution

### DIFF
--- a/examples/workflow-theia/src/node/workflow-glsp-server-contribution.ts
+++ b/examples/workflow-theia/src/node/workflow-glsp-server-contribution.ts
@@ -13,7 +13,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import { getPort, JavaSocketServerContribution, JavaSocketServerLaunchOptions } from '@eclipse-glsp/theia-integration/lib/node';
+import { getPort, GLSPSocketServerContribution, GLSPSocketServerContributionOptions } from '@eclipse-glsp/theia-integration/lib/node';
 import { injectable } from '@theia/core/shared/inversify';
 import { join, resolve } from 'path';
 import { WorkflowLanguage } from '../common/workflow-language';
@@ -24,12 +24,12 @@ export const SERVER_DIR = join(__dirname, '..', '..', 'server');
 export const JAR_FILE = resolve(join(SERVER_DIR, 'org.eclipse.glsp.example.workflow-0.10.0-SNAPSHOT-glsp.jar'));
 
 @injectable()
-export class WorkflowGLServerContribution extends JavaSocketServerContribution {
+export class WorkflowGLServerContribution extends GLSPSocketServerContribution {
     readonly id = WorkflowLanguage.contributionId;
 
-    createLaunchOptions(): Partial<JavaSocketServerLaunchOptions> {
+    createContributionOptions(): Partial<GLSPSocketServerContributionOptions> {
         return {
-            jarPath: JAR_FILE,
+            executable: JAR_FILE,
             additionalArgs: ['--consoleLog', 'false', '--fileLog', 'true', '--logDir', SERVER_DIR],
             socketConnectionOptions: {
                 port: getPort(PORT_ARG_KEY, DEFAULT_PORT)

--- a/packages/theia-integration/src/node/glsp-backend-contribution.ts
+++ b/packages/theia-integration/src/node/glsp-backend-contribution.ts
@@ -17,7 +17,7 @@ import { ContributionProvider, ILogger } from '@theia/core/lib/common';
 import { MessagingService } from '@theia/core/lib/node/messaging/messaging-service';
 import { inject, injectable, named } from '@theia/core/shared/inversify';
 import { GLSPContribution } from '../common';
-import { GLSPServerContribution, GLSPServerLaunchOptions } from './glsp-server-contribution';
+import { GLSPServerContribution, GLSPServerContributionOptions } from './glsp-server-contribution';
 
 @injectable()
 export class GLSPBackendContribution implements MessagingService.Contribution, GLSPContribution.Service {
@@ -47,7 +47,7 @@ export class GLSPBackendContribution implements MessagingService.Contribution, G
     configure(service: MessagingService): void {
         for (const contribution of this.contributors.getContributions()) {
             const path = GLSPContribution.getPath(contribution);
-            if (GLSPServerLaunchOptions.shouldLaunchOnApplicationStart(contribution)) {
+            if (GLSPServerContributionOptions.shouldLaunchOnApplicationStart(contribution)) {
                 contribution.launch!().then(() => this.forward(service, path, contribution));
             } else {
                 this.forward(service, path, contribution);

--- a/packages/theia-integration/src/node/glsp-server-contribution.ts
+++ b/packages/theia-integration/src/node/glsp-server-contribution.ts
@@ -29,7 +29,7 @@ export const GLSPServerContribution = Symbol.for('GLSPServerContribution');
 
 /**
  * The backend service component of a {@link GLSPContribution}. Responsible for launching new
- * GLSP server processes and connecting to a running server instance.
+ * GLSP server processes or connecting to a running server instance.
  */
 export interface GLSPServerContribution extends GLSPContribution {
     /**
@@ -51,13 +51,13 @@ export interface GLSPServerContribution extends GLSPContribution {
 }
 
 /**
- * Configurable options for a {@link GLSPServerContribution}.
+ * Configuration options for a {@link GLSPServerContribution}.
  */
 export interface GLSPServerContributionOptions {
     /** Declares wether the  server should be launched on application start or on demand (e.g. on widget open). */
     launchOnDemand: boolean;
     /**
-     * Declares that the server contribution does not have to consider server launching. This will be done externally.
+     * Declares that the server contribution does not have to launch a server but expects it to be already started.
      * Mostly used for debugging purposes during development.
      */
     launchedExternally: boolean;

--- a/packages/theia-integration/src/node/glsp-server-contribution.ts
+++ b/packages/theia-integration/src/node/glsp-server-contribution.ts
@@ -27,6 +27,10 @@ import { GLSPContribution } from '../common';
 
 export const GLSPServerContribution = Symbol.for('GLSPServerContribution');
 
+/**
+ * The backend service component of a {@link GLSPContribution}. Responsible for launching new
+ * GLSP server processes and connecting to a running server instance.
+ */
 export interface GLSPServerContribution extends GLSPContribution {
     /**
      * Establish a connection between the given client (connection) and the GLSP server.
@@ -41,34 +45,31 @@ export interface GLSPServerContribution extends GLSPContribution {
     launch?(): Promise<void>;
 
     /**
-     * The {@link GLSPServerLaunchOptions} for this contribution.
+     * The {@link GLSPServerContributionOptions} for this contribution.
      */
-    launchOptions: GLSPServerLaunchOptions;
+    options: GLSPServerContributionOptions;
 }
-export interface GLSPServerLaunchOptions {
-    /**
-     * Declares if the server can handle multiple clients.
-     * A `multiClient` server only has to be started once whereas in a `singleClient` scenario a new server needs to be launched for each
-     * client.
-     */
-    multiClient: boolean;
+
+/**
+ * Configurable options for a {@link GLSPServerContribution}.
+ */
+export interface GLSPServerContributionOptions {
     /** Declares wether the  server should be launched on application start or on demand (e.g. on widget open). */
     launchOnDemand: boolean;
     /**
      * Declares that the server contribution does not have to consider server launching. This will be done externally.
-     * Mostly used for debug purposes.
+     * Mostly used for debugging purposes during development.
      */
     launchedExternally: boolean;
 }
 
-export namespace GLSPServerLaunchOptions {
-    /** Default values for {@link GLSPServerLaunchOptions } **/
-    export function createDefaultOptions(): GLSPServerLaunchOptions {
+export namespace GLSPServerContributionOptions {
+    /** Default values for {@link GLSPServerContributionOptions } **/
+    export function createDefaultOptions(): GLSPServerContributionOptions {
         return {
-            multiClient: true,
             launchOnDemand: false,
             launchedExternally: inDebugMode()
-        } as GLSPServerLaunchOptions;
+        } as GLSPServerContributionOptions;
     }
 
     /**
@@ -76,12 +77,12 @@ export namespace GLSPServerLaunchOptions {
      * options that are not specified.
      * @param options (partial) launch options that should be extended with default values (if necessary).
      */
-    export function configure(options?: Partial<GLSPServerLaunchOptions>): GLSPServerLaunchOptions {
+    export function configure(options?: Partial<GLSPServerContributionOptions>): GLSPServerContributionOptions {
         return options
             ? ({
                   ...createDefaultOptions(),
                   ...options
-              } as GLSPServerLaunchOptions)
+              } as GLSPServerContributionOptions)
             : createDefaultOptions();
     }
 
@@ -104,11 +105,7 @@ export namespace GLSPServerLaunchOptions {
      * @returns `true` if the server should be launched on application start.
      */
     export function shouldLaunchOnApplicationStart(contribution: GLSPServerContribution): boolean {
-        return (
-            contribution.launch !== undefined &&
-            !contribution.launchOptions.launchOnDemand &&
-            !contribution.launchOptions.launchedExternally
-        );
+        return contribution.launch !== undefined && !contribution.options.launchOnDemand && !contribution.options.launchedExternally;
     }
 }
 
@@ -118,21 +115,25 @@ export namespace GLSPServerLaunchOptions {
  */
 @injectable()
 export abstract class BaseGLSPServerContribution implements GLSPServerContribution {
-    @inject(RawProcessFactory) protected readonly processFactory: RawProcessFactory;
-    @inject(ProcessManager) protected readonly processManager: ProcessManager;
-    abstract readonly id: string;
-    launchOptions: GLSPServerLaunchOptions = GLSPServerLaunchOptions.createDefaultOptions();
+    @inject(RawProcessFactory)
+    protected readonly processFactory: RawProcessFactory;
 
-    abstract connect(clientConnection: IConnection): void;
+    @inject(ProcessManager)
+    protected readonly processManager: ProcessManager;
+
+    abstract readonly id: string;
+    options: GLSPServerContributionOptions;
 
     @postConstruct()
     protected initialize(): void {
-        if (this.createLaunchOptions) {
-            this.launchOptions = GLSPServerLaunchOptions.configure(this.createLaunchOptions());
-        }
+        this.options = this.createContributionOptions
+            ? GLSPServerContributionOptions.configure(this.createContributionOptions())
+            : GLSPServerContributionOptions.createDefaultOptions();
     }
 
-    abstract createLaunchOptions?(): Partial<GLSPServerLaunchOptions>;
+    abstract connect(clientConnection: IConnection): void;
+
+    abstract createContributionOptions?(): Partial<GLSPServerContributionOptions>;
 
     protected forward(clientConnection: IConnection, serverConnection: IConnection): void {
         forward(clientConnection, serverConnection);

--- a/packages/theia-integration/src/node/glsp-socket-server-contribution.ts
+++ b/packages/theia-integration/src/node/glsp-socket-server-contribution.ts
@@ -22,7 +22,7 @@ import { BaseGLSPServerContribution, GLSPServerContributionOptions } from './gls
 
 /**
  * Message that is expected to be printed by the embedded server process to the stdout once the
- * server process startup routine has been completed.
+ * server process startup routine has been completed and is ready to accept incoming connections.
  */
 export const START_UP_COMPLETE_MSG = '[GLSP-Server]:Startup completed';
 

--- a/packages/theia-integration/src/node/index.ts
+++ b/packages/theia-integration/src/node/index.ts
@@ -15,4 +15,4 @@
  ********************************************************************************/
 export * from './glsp-backend-contribution';
 export * from './glsp-server-contribution';
-export * from './java-socket-glsp-server';
+export * from './glsp-socket-server-contribution';


### PR DESCRIPTION
Refactor JavaSocketServerContribution to `GLSPSocketContribution` and rework launch options so that they support both
launch an embedded java or node server.

Also: refactor and cleanup `GLSPServerContribution` API

Fixes https://github.com/eclipse-glsp/glsp/issues/636