### PR TITLE
Remove focus outline of GLSP Theia editor

### DIFF
--- a/packages/theia-integration/css/diagram.css
+++ b/packages/theia-integration/css/diagram.css
@@ -14,6 +14,10 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+.sprotty > div:focus {
+    outline: none;
+}
+
 .sprotty-graph {
     background: var(--theia-editor-background);
 }


### PR DESCRIPTION
Due to some Theia upgrade, we seem to have now a border on `:focus` around our diagram. This is inconsistent with other editors, such as the text editor in Theia.

Thus we should remove this editor border by default.

Change-Id: Iddf06205848f832f490dd62e0c1ad62bdeb2f9f7