### PR TITLE
#756: Ensure diagram widget accepts focus on SVG element

### DIFF
--- a/packages/theia-integration/src/browser/diagram/glsp-diagram-widget.ts
+++ b/packages/theia-integration/src/browser/diagram/glsp-diagram-widget.ts
@@ -134,8 +134,21 @@ export class GLSPDiagramWidget extends DiagramWidget implements SaveableSource {
     }
 
     protected override onActivateRequest(msg: Message): void {
+        this.makeFocusable(this.node.querySelector(`#${this.viewerOptions.baseDiv} svg`));
         super.onActivateRequest(msg);
         this.updateGlobalSelection();
+    }
+
+    protected makeFocusable(element: Element | null): void {
+        // eslint-disable-next-line no-null/no-null
+        if (element !== null) {
+            const tabindex = element.getAttribute('tabindex');
+            // eslint-disable-next-line no-null/no-null
+            if (tabindex === null) {
+                // use -1 to make focusable but not reachable via keyboard navigation
+                element.setAttribute('tabindex', '-1');
+            }
+        }
     }
 
     get diagramType(): string {


### PR DESCRIPTION
- Make SVG element 'focusable' by adding the tabIndex attribute

Fixes https://github.com/eclipse-glsp/glsp/issues/756

![fix-focus](https://user-images.githubusercontent.com/19170971/193815383-5aa972fe-ff81-4a99-81c6-774fc9aa5995.gif)
