### PR TITLE
Ensure that startup UI extensions are rendered correctly

### DIFF
--- a/examples/workflow-theia/package.json
+++ b/examples/workflow-theia/package.json
@@ -36,7 +36,7 @@
   },
   "scripts": {
     "build": "tsc -b",
-    "clean": "rimraf lib tsconfig.tsbuildinfo",
+    "clean": "rimraf lib tsconfig.tsbuildinfo server/*.log",
     "lint": "eslint --ext .ts,.tsx ./src",
     "lint:ci": "yarn lint -o eslint.xml -f checkstyle",
     "prepare": "yarn clean && yarn build",

--- a/packages/theia-integration/README.md
+++ b/packages/theia-integration/README.md
@@ -16,7 +16,7 @@ If that is the case, a new compatible 1.0.0 version prefixed with the supported 
 | 0.9.0                           | >=1.20.0 <= 1.25.0 |
 | 1.0.0                           | >=1.25.0 <= 1.26.0 |
 | 1.0.0-theia1.27.0               | >=1.27.0           |
-| next                            | >=1.27.0           |
+| next                            | >=1.33.0           |
 
 > Note: Due to a transitive dependency to `sprotty-theia` it's currently not possible to safely restrict the maximum version of Theia packages. If you encounter build errors related to multiple resolved Theia versions please add a resolutions block to the `package.json` of your project e.g. for `1.0.0-theia1.27.0`:
 

--- a/packages/theia-integration/src/browser/diagram/glsp-diagram-widget.ts
+++ b/packages/theia-integration/src/browser/diagram/glsp-diagram-widget.ts
@@ -101,11 +101,17 @@ export class GLSPDiagramWidget extends DiagramWidget implements SaveableSource {
         this.dispatchInitialActions();
     }
 
+    override get actionDispatcher(): GLSPActionDispatcher {
+        return this.diContainer.get(TYPES.IActionDispatcher);
+    }
+
     protected dispatchInitialActions(): void {
         this.actionDispatcher.dispatch(RequestModelAction.create({ options: this.requestModelOptions }));
         this.actionDispatcher.dispatch(RequestTypeHintsAction.create());
-        this.actionDispatcher.dispatch(EnableToolPaletteAction.create());
         this.actionDispatcher.dispatch(SetEditModeAction.create(this.options.editMode));
+        this.actionDispatcher.onceModelInitialized().then(() => {
+            this.actionDispatcher.dispatch(EnableToolPaletteAction.create());
+        });
     }
 
     protected override onAfterAttach(msg: Message): void {


### PR DESCRIPTION
UI extensions that should be active i.e. visible on startup might be activated to early (before the initial model loading is completed) which can cause rendering issues in some cases. This can be avoided by enabling these UI extensions after the model has been initialized. Closes https://github.com/eclipse-glsp/glsp/issues/585

Also
- Update theia-version range in README of `@eclipse-glsp/theia-integration`
- Ensure that logs of the downloaded server get properly cleaned