### PR TITLE
Ensure that browser-app is no excluded from workspaces build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,9 +10,9 @@ yarn-error.log
 
 *.log
 
-examples/browser-app/**
-!examples/browser-app/package.json
-!examples/browser-app/webpack.config.js
+examples/browser-app/src-gen/
+examples/browser-app/gen-webpack.config.js
+
 examples/**/server/**
 !examples/**/server/download.ts
 tsconfig.tsbuildinfo


### PR DESCRIPTION
Newer lerna/nx versions don't build projects whose root folder is gitignored 
=> update .gitignore to ensure that the browser-app is properly included into the lerna workspaces 
Fixes https://github.com/eclipse-glsp/glsp/issues/952