### PR TITLE
feat: adjust server startup to use autoassigned ports

### DIFF
--- a/examples/browser-app/package.json
+++ b/examples/browser-app/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "theia build --mode development",
     "prepare": "yarn build",
-    "start": "theia start --WF_GLSP=5007 --root-dir=../workspace",
+    "start": "theia start --WF_GLSP=0 --root-dir=../workspace",
     "start:debug": "theia start --WF_GLSP=5007  --root-dir=../workspace --loglevel=debug --debug",
     "watch": "theia build --watch --mode development"
   },

--- a/examples/workflow-theia/src/node/workflow-glsp-server-contribution.ts
+++ b/examples/workflow-theia/src/node/workflow-glsp-server-contribution.ts
@@ -19,7 +19,7 @@ import { join, resolve } from 'path';
 import { WorkflowLanguage } from '../common/workflow-language';
 import * as config from './server-config.json';
 
-export const DEFAULT_PORT = 5007;
+export const DEFAULT_PORT = 0;
 export const PORT_ARG_KEY = 'WF_GLSP';
 export const SERVER_DIR = join(__dirname, '..', '..', 'server');
 const { version, isSnapShot } = config;


### PR DESCRIPTION
All our GLSP server implementations are now capable of port autoassignment. The listening port is printed to STDOUT when the server is launched and has to be parsed by clients.

This patch adjusts the Theia integration to use the new port autoassignment.

Part of eclipse-glsp/glsp/issues/965