### PR TITLE
#984 WebSocket Communication in Theia GLSP 

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -39,6 +39,39 @@
     {
       "type": "node",
       "request": "launch",
+      "name": "Launch Workflow Browser Backend (WebSocket GLSP Server)",
+      "program": "${workspaceRoot}/examples/browser-app/src-gen/backend/main.js",
+      "args": [
+        "--hostname=localhost",
+        "--WF_GLSP=8081",
+        "--webSocket=workflow",
+        "--port=3000",
+        "--no-cluster",
+        "--root-dir=${workspaceRoot}/examples/workspace",
+        "--app-project-path=${workspaceRoot}/examples/browser-app"
+      ],
+      "env": {
+        "NODE_ENV": "development"
+      },
+      "sourceMaps": true,
+      "outFiles": [
+        "${workspaceRoot}/node_modules/@theia/*/lib/**/*.js",
+        "${workspaceRoot}/examples/browser-app/lib/**/*.js",
+        "${workspaceRoot}/examples/browser-app/src-gen/**/*.js",
+        "${workspaceRoot}/packages/*/lib/**/*.js",
+        "${workspaceRoot}/examples/*/lib/**/*.js"
+      ],
+      "smartStep": true,
+      "internalConsoleOptions": "openOnSessionStart",
+      "outputCapture": "std",
+      "presentation": {
+        "group": "Browser launch configurations",
+        "order": 1
+      }
+    },
+    {
+      "type": "node",
+      "request": "launch",
       "name": "Launch Workflow Browser Backend (External GLSP Server)",
       "program": "${workspaceRoot}/examples/browser-app/src-gen/backend/main.js",
       "args": [
@@ -49,10 +82,79 @@
         "--root-dir=${workspaceRoot}/examples/workspace",
         "--app-project-path=${workspaceRoot}/examples/browser-app",
         "--debug",
-        "--loglevel=debug"
+        "--logLevel=debug"
       ],
       "env": {
         "NODE_ENV": "development"
+      },
+      "sourceMaps": true,
+      "outFiles": [
+        "${workspaceRoot}/node_modules/@theia/*/lib/**/*.js",
+        "${workspaceRoot}/examples/browser-app/lib/**/*.js",
+        "${workspaceRoot}/examples/browser-app/src-gen/**/*.js",
+        "${workspaceRoot}/packages/*/lib/**/*.js",
+        "${workspaceRoot}/examples/*/lib/**/*.js"
+      ],
+      "smartStep": true,
+      "internalConsoleOptions": "openOnSessionStart",
+      "outputCapture": "std",
+      "presentation": {
+        "group": "Browser launch configurations",
+        "order": 1
+      }
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Launch Workflow Browser Backend (External Websocket GLSP Server)",
+      "program": "${workspaceRoot}/examples/browser-app/src-gen/backend/main.js",
+      "args": [
+        "--hostname=localhost",
+        "--WF_GLSP=8081",
+        "--webSocket=workflow",
+        "--port=3000",
+        "--no-cluster",
+        "--root-dir=${workspaceRoot}/examples/workspace",
+        "--app-project-path=${workspaceRoot}/examples/browser-app",
+        "--debug",
+        "--logLevel=debug"
+      ],
+      "env": {
+        "NODE_ENV": "development"
+      },
+      "sourceMaps": true,
+      "outFiles": [
+        "${workspaceRoot}/node_modules/@theia/*/lib/**/*.js",
+        "${workspaceRoot}/examples/browser-app/lib/**/*.js",
+        "${workspaceRoot}/examples/browser-app/src-gen/**/*.js",
+        "${workspaceRoot}/packages/*/lib/**/*.js",
+        "${workspaceRoot}/examples/*/lib/**/*.js"
+      ],
+      "smartStep": true,
+      "internalConsoleOptions": "openOnSessionStart",
+      "outputCapture": "std",
+      "presentation": {
+        "group": "Browser launch configurations",
+        "order": 1
+      }
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Launch Theia Browser Backend (Direct WebSocket GLSP Server connection from frontend)",
+      "program": "${workspaceRoot}/examples/browser-app/src-gen/backend/main.js",
+      "args": [
+        "--hostname=localhost",
+        "--directWebSocket",
+        "--port=3000",
+        "--no-cluster",
+        "--root-dir=${workspaceRoot}/examples/workspace",
+        "--app-project-path=${workspaceRoot}/examples/browser-app",
+        "--logLevel=debug"
+      ],
+      "env": {
+        "NODE_ENV": "development",
+        "WEBSOCKET_PORT": "8081"
       },
       "sourceMaps": true,
       "outFiles": [

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,7 @@
       "program": "${workspaceRoot}/examples/browser-app/src-gen/backend/main.js",
       "args": [
         "--hostname=localhost",
-        "--WF_GLSP=5007",
+        "--WF_GLSP=0",
         "--port=3000",
         "--no-cluster",
         "--root-dir=${workspaceRoot}/examples/workspace",
@@ -43,7 +43,7 @@
       "program": "${workspaceRoot}/examples/browser-app/src-gen/backend/main.js",
       "args": [
         "--hostname=localhost",
-        "--WF_GLSP=8081",
+        "--WF_GLSP=0",
         "--webSocket=workflow",
         "--port=3000",
         "--no-cluster",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -37,10 +37,32 @@
       "problemMatcher": []
     },
     {
+      "label": "[Theia] Start Workflow Theia Backend Example (WebSocket Server)",
+      "type": "shell",
+      "group": "test",
+      "command": "cd examples/browser-app && yarn start:ws",
+      "presentation": {
+        "reveal": "always",
+        "panel": "new"
+      },
+      "problemMatcher": []
+    },
+    {
       "label": "[Theia] Start Workflow Theia Backend Example (DEBUG)",
       "type": "shell",
       "group": "test",
       "command": "cd examples/browser-app && yarn start:debug",
+      "presentation": {
+        "reveal": "always",
+        "panel": "new"
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "[Theia] Start Workflow Theia Backend Example (WebSocket Server) (DEBUG)",
+      "type": "shell",
+      "group": "test",
+      "command": "cd examples/browser-app && yarn start:ws:debug",
       "presentation": {
         "reveal": "always",
         "panel": "new"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 -   [diagram] Refactored `GLSPDiagramConfiguration`. Diagram containers are now child containers of the Theia DI container [#152](https://github.com/eclipse-glsp/glsp-theia-integration/pull/1525)
     -   `GLSPDiagramConfiguration`
         -   `doCreateContainer` method has been renamed to `configureContainer` and requires additional arguments.
+-   [theia] BaseGLSPClientContribution: changed `createGLSPClient(connectionProvider: ConnectionProvider)` to an async function
 
 ## [1.0.0 - 30/06/2022](https://github.com/eclipse-glsp/glsp-theia-integration/releases/tag/v1.0.0)
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ See [our project website](https://www.eclipse.org/glsp/documentation/#workflowov
 
 > _**Remark:**_ The workflow example is a fully dev example, as it combines a variety of integration and connectivity options to easily test the different use cases. However, it should not be used as a blueprint for your custom implementation, for this we recommend the [GLSP project templates](https://github.com/eclipse-glsp/glsp-examples/tree/master/project-templates) in the GLSP example repository.
 
-https://user-images.githubusercontent.com/588090/154459938-849ca684-11b3-472c-8a59-98ea6cb0b4c1.mp4
+<https://user-images.githubusercontent.com/588090/154459938-849ca684-11b3-472c-8a59-98ea6cb0b4c1.mp4>
 
 ### How to start the Workflow Diagram example?
 
@@ -81,11 +81,7 @@ The default example use case uses a socket communication from the backend to the
 
 To communicate with the server via WebSockets, there are two options available:
 
-#### Connect to GLSP server from Theia backend via WebSockets
-
-Extend SocketServerContribution to allow starting server in WebSocket mode
-Introduce WebSocketConnectionForwarder
-Add launch configs and scripts to start workflow example in WebSocket mode
+#### **1. Connect to GLSP server from Theia backend via WebSockets**
 
 To connect to the example GLSP server in WebSocket mode from the backend, this can be achieved by passing the CLI argument `--webSocket=<path>`.
 In the example the argument to be passed is `--webSocket=workflow`.
@@ -101,7 +97,7 @@ The example provides scripts and launch configs that pass this argument to test 
     -   VS Code Launch config: `Launch Workflow Browser Backend (External Websocket GLSP Server)`
     -   Script: `yarn start:ws:debug`
 
-#### Connect directly to GLSP server from frontend via WebSockets
+#### **2. Connect directly to GLSP server from frontend via WebSockets**
 
 This skips binding of the GLSP backend contribution if `--directWebSocket` argument is passed to the Theia backend.
 The workflow diagram example frontend additionally expects an environment variable (e.g. `"WEBSOCKET_PORT=8081"`) to trigger the direct connection from the GLSP frontend client to the running GLSP WebSocket Server.
@@ -119,6 +115,7 @@ The workflow example provides a launch config that passes the argument sets the 
 In addition to this repository, the related source code can be found here:
 
 -   <https://github.com/eclipse-glsp/glsp-server>
+-   <https://github.com/eclipse-glsp/glsp-server-node>
 -   <https://github.com/eclipse-glsp/glsp-client>
 
 ## More information

--- a/README.md
+++ b/README.md
@@ -40,8 +40,10 @@ If that is the case, a new compatible 1.0.0 version prefixed with the supported 
 The workflow diagram is a consistent example provided by all GLSP components.
 The example implements a simple flow chart diagram editor with different types of nodes and edges (see screenshot below).
 The example can be used to try out different GLSP features, as well as several available integrations with IDE platforms (Theia, VSCode, Eclipse, Standalone).
-As the example is fully open source, you can also use it as a blueprint for a custom implementation of a GLSP diagram editor.
+It also offers different server connectivity possibilities such as socket or websocket connections.
 See [our project website](https://www.eclipse.org/glsp/documentation/#workflowoverview) for an overview of the workflow example and all components implementing it.
+
+> _**Remark:**_ The workflow example is a fully dev example, as it combines a variety of integration and connectivity options to easily test the different use cases. However, it should not be used as a blueprint for your custom implementation, for this we recommend the [GLSP project templates](https://github.com/eclipse-glsp/glsp-examples/tree/master/project-templates) in the GLSP example repository.
 
 https://user-images.githubusercontent.com/588090/154459938-849ca684-11b3-472c-8a59-98ea6cb0b4c1.mp4
 
@@ -72,6 +74,45 @@ Once the Workflow Diagram Server is running, start the Theia application with th
 cd examples/browser-app
 yarn start:debug
 ```
+
+### Start Workflow Diagram example in WebSocket mode
+
+The default example use case uses a socket communication from the backend to the GLSP server.
+
+To communicate with the server via WebSockets, there are two options available:
+
+#### Connect to GLSP server from Theia backend via WebSockets
+
+Extend SocketServerContribution to allow starting server in WebSocket mode
+Introduce WebSocketConnectionForwarder
+Add launch configs and scripts to start workflow example in WebSocket mode
+
+To connect to the example GLSP server in WebSocket mode from the backend, this can be achieved by passing the CLI argument `--webSocket=<path>`.
+In the example the argument to be passed is `--webSocket=workflow`.
+
+The example provides scripts and launch configs that pass this argument to test this connectivity option either in embedded or debug mode:
+
+-   Embedded: Start a Java GLSP server in WebSocket mode along with the backend:
+
+    -   VS Code Launch config: `Launch Workflow Browser Backend (WebSocket GLSP Server)`
+    -   Script: `yarn start:ws`
+
+-   Debug mode: Expects a running GLSP server (Java or node.js) in WebSocket mode:
+    -   VS Code Launch config: `Launch Workflow Browser Backend (External Websocket GLSP Server)`
+    -   Script: `yarn start:ws:debug`
+
+#### Connect directly to GLSP server from frontend via WebSockets
+
+This skips binding of the GLSP backend contribution if `--directWebSocket` argument is passed to the Theia backend.
+The workflow diagram example frontend additionally expects an environment variable (e.g. `"WEBSOCKET_PORT=8081"`) to trigger the direct connection from the GLSP frontend client to the running GLSP WebSocket Server.
+In this case, we do not have any GLSP backend contribution which means, the GLSP server instance is not started automatically, and needs either to be started manually or by some other party.
+
+The workflow example provides a launch config that passes the argument sets the environment variable:
+
+-   Debug mode: Expects a running GLSP server (Java or node.js) in WebSocket mode:
+    -   VS Code Launch config: `Launch Theia Browser Backend (Direct WebSocket GLSP Server connection from frontend)`
+
+> _**Remark:**_ In production, one would decide for one way of connectivity, and would not implement all the different options as we do in the workflow diagram example. This was setup to easily show and switch between the different possibilities.
 
 ### Where to find the sources?
 

--- a/examples/browser-app/package.json
+++ b/examples/browser-app/package.json
@@ -7,6 +7,8 @@
     "prepare": "yarn build",
     "start": "theia start --WF_GLSP=0 --root-dir=../workspace",
     "start:debug": "theia start --WF_GLSP=5007  --root-dir=../workspace --loglevel=debug --debug",
+    "start:ws": "theia start --WF_GLSP=0 --webSocket=workflow --root-dir=../workspace",
+    "start:ws:debug": "theia start --WF_GLSP=8081 --webSocket=workflow --root-dir=../workspace --logLevel=debug --debug",
     "watch": "theia build --watch --mode development"
   },
   "dependencies": {

--- a/examples/workflow-theia/src/node/workflow-backend-module.ts
+++ b/examples/workflow-theia/src/node/workflow-backend-module.ts
@@ -20,5 +20,19 @@ import { ContainerModule } from '@theia/core/shared/inversify';
 import { WorkflowGLServerContribution } from './workflow-glsp-server-contribution';
 
 export default new ContainerModule(bind => {
-    bindAsService(bind, GLSPServerContribution, WorkflowGLServerContribution);
+    if (!isDirectWebSocketConnection()) {
+        bindAsService(bind, GLSPServerContribution, WorkflowGLServerContribution);
+    }
 });
+
+const directWebSocketArg = '--directWebSocket';
+/**
+ * Utility function to parse if the frontend should connect directly to a running GLSP WebSocket Server instance
+ * and skip the binding of the backend contribution.
+ * i.e. if the {@link directWebSocketArg `--directWebSocket`} argument has been passed.
+ * @returns `true` if the {@link directWebSocketArg `--directWebSocket`} argument has been set.
+ */
+function isDirectWebSocketConnection(): boolean {
+    const args = process.argv.filter(a => a.toLowerCase().startsWith(directWebSocketArg.toLowerCase()));
+    return args.length > 0;
+}

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     "publish:prepare": "lerna version --ignore-scripts --yes --no-push",
     "start": "yarn --cwd examples/browser-app start",
     "start:debug": "yarn --cwd examples/browser-app start:debug",
+    "start:ws": "yarn --cwd examples/browser-app start:ws",
+    "start:ws:debug": "yarn --cwd examples/browser-app start:ws:debug",
     "upgrade:next": "yarn upgrade -p \"@eclipse-glsp.*\" --next ",
     "watch": "lerna run --parallel watch"
   },

--- a/packages/theia-integration/package.json
+++ b/packages/theia-integration/package.json
@@ -44,7 +44,11 @@
     "watch": "tsc -w"
   },
   "dependencies": {
-    "@eclipse-glsp/client": "next"
+    "@eclipse-glsp/client": "next",
+    "ws": "~8.11.0"
+  },
+  "devDependencies": {
+    "@types/ws": "^8.5.4"
   },
   "peerDependencies": {
     "@theia/core": "^1.34.0",

--- a/packages/theia-integration/src/browser/glsp-client-contribution.ts
+++ b/packages/theia-integration/src/browser/glsp-client-contribution.ts
@@ -131,13 +131,13 @@ export abstract class BaseGLSPClientContribution implements GLSPClientContributi
             this.connectionProvider.listen(
                 {
                     path: GLSPContribution.getPath(this),
-                    onConnection: channel => {
+                    onConnection: async channel => {
                         if (this.toDispose.disposed) {
                             channel.close();
                             return;
                         }
                         const connection = createChannelConnection(channel);
-                        const client = this.createGLSPClient(connection);
+                        const client = await this.createGLSPClient(connection);
                         this.start(client);
                         this.toDispose.pushAll([
                             Disposable.create(() => {
@@ -186,7 +186,7 @@ export abstract class BaseGLSPClientContribution implements GLSPClientContributi
         return undefined;
     }
 
-    protected createGLSPClient(connectionProvider: ConnectionProvider): GLSPClient {
+    protected async createGLSPClient(connectionProvider: ConnectionProvider): Promise<GLSPClient> {
         return new TheiaJsonrpcGLSPClient({
             id: this.id,
             connectionProvider,

--- a/packages/theia-integration/src/browser/theia-jsonrpc-glsp-client.ts
+++ b/packages/theia-integration/src/browser/theia-jsonrpc-glsp-client.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2020-2022 EclipseSource and others.
+ * Copyright (c) 2020-2023 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,11 +14,13 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 import { BaseJsonrpcGLSPClient, ClientState, JsonrpcGLSPClient } from '@eclipse-glsp/client';
+import { listen } from '@eclipse-glsp/protocol';
 import { MessageService } from '@theia/core/';
-import { Message } from 'vscode-jsonrpc';
+import { Message, MessageConnection } from 'vscode-jsonrpc';
 
 export class TheiaJsonrpcGLSPClient extends BaseJsonrpcGLSPClient {
     protected messageService: MessageService;
+    protected webSocketPort?: number;
 
     constructor(options: TheiaJsonrpcGLSPClient.Options) {
         super(options);
@@ -45,12 +47,23 @@ export class TheiaJsonrpcGLSPClient extends BaseJsonrpcGLSPClient {
         }
         return super.checkConnectionState();
     }
+
+    protected override doCreateConnection(): Promise<MessageConnection> {
+        if (this.webSocketPort) {
+            const websocket = new WebSocket(`ws://localhost:${this.webSocketPort}/${this.id}`);
+            // creates a new MessageConnection on top of the given websocket on open.
+            return listen(websocket);
+        }
+        return super.doCreateConnection();
+    }
 }
 
 // eslint-disable-next-line no-redeclare
 export namespace TheiaJsonrpcGLSPClient {
     export interface Options extends JsonrpcGLSPClient.Options {
         messageService: MessageService;
+        /** Indicates if the frontend should connect directly to a running WebSocket GLSP server instance. */
+        webSocketPort?: number;
     }
 
     export function isOptions(object: any): object is Options {

--- a/packages/theia-integration/src/node/websocket-connection-forwarder.ts
+++ b/packages/theia-integration/src/node/websocket-connection-forwarder.ts
@@ -1,0 +1,93 @@
+/********************************************************************************
+ * Copyright (c) 2023 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+import { WebSocketWrapper, createWebSocketConnection } from '@eclipse-glsp/protocol';
+import { Channel, Disposable, DisposableCollection } from '@theia/core';
+import { MessageConnection } from '@theia/core/shared/vscode-languageserver-protocol';
+import { WebSocket } from 'ws';
+
+/**
+ * Creates a new vscode-jsonrpc {@link MessageConnection} on top of a given WebSocket.
+ * It handles messages between then service client channel and the given WebSocket.
+ */
+export class WebSocketConnectionForwarder implements Disposable {
+    protected toDispose = new DisposableCollection();
+
+    protected initialChannelListener: Disposable;
+    protected initialBufferStore: Uint8Array[] = [];
+
+    constructor(protected readonly clientChannel: Channel, protected readonly webSocket: WebSocket) {
+        /**
+         * The webSocket connection is successfully established `onOpen`
+         * The service client channel however, might send message (i.e. the InitializeRequest) once the backend contribution is resolved.
+         * In this case, the listener could not yet be successfully registered, hence we buffer such messages and process them,
+         * once the webSocket connection was successfully established.
+         */
+        this.initialChannelListener = this.clientChannel.onMessage(msgProvider => {
+            const buffer = msgProvider().readBytes();
+            this.initialBufferStore.push(buffer);
+        });
+
+        webSocket.onopen = () => {
+            this.initialize(webSocket);
+        };
+    }
+
+    protected initialize(webSocket: WebSocket): void {
+        const wrappedWebSocket = wrapWebSocket(webSocket);
+        const connection: MessageConnection = createWebSocketConnection(wrappedWebSocket);
+        connection.listen();
+
+        this.toDispose.pushAll([
+            connection.onClose(() => webSocket.close()),
+            this.clientChannel.onMessage(msgProvider => {
+                const buffer = msgProvider().readBytes();
+                wrappedWebSocket.send(new TextDecoder().decode(buffer));
+            }),
+            connection.onClose(() => this.clientChannel.close()),
+            Disposable.create(() => {
+                this.clientChannel.close();
+                connection.dispose();
+            })
+        ]);
+        webSocket.on('message', msg => {
+            this.clientChannel
+                .getWriteBuffer()
+                .writeBytes(msg as Buffer)
+                .commit();
+        });
+
+        // process initially received buffer messages
+        this.initialChannelListener.dispose();
+        this.initialBufferStore.map(msg => {
+            wrappedWebSocket.send(new TextDecoder().decode(msg));
+        });
+        this.initialBufferStore = [];
+    }
+
+    dispose(): void {
+        this.toDispose.dispose();
+    }
+}
+
+export function wrapWebSocket(socket: WebSocket): WebSocketWrapper {
+    return {
+        send: content => socket.send(content),
+        onMessage: cb => socket.on('message', cb),
+        onClose: cb => socket.on('close', cb),
+        onError: cb => socket.on('error', cb),
+        dispose: () => socket.close()
+    };
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2763,6 +2763,13 @@
     "@types/events" "*"
     "@types/node" "*"
 
+"@types/ws@^8.5.4":
+  version "8.5.4"
+  resolved "https://registry.yarnpkg.com/@types/ws/-/ws-8.5.4.tgz#bb10e36116d6e570dd943735f86c933c1587b8a5"
+  integrity sha512-zdQDHKUgcX/zBc4GrwsE/7dVdAD8JR4EuiAXiiUhhfyIJXXb2+PrGshFyeXWQPMmmZ2XxgaqclgpIC7eTXc1mg==
+  dependencies:
+    "@types/node" "*"
+
 "@types/yargs-parser@*":
   version "21.0.0"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-21.0.0.tgz#0c60e537fa790f5f9472ed2776c2b71ec117351b"


### PR DESCRIPTION
- Use WebSocket communication to GLSP server from Theia backend
  - Extend SocketServerContribution to allow starting server in WebSocket mode
  - Introduce WebSocketConnectionForwarder
  - Add launch configs and scripts to start workflow example in WebSocket mode
- Connect directly to GLSP WebSocket server from frontend
  - Skip binding of backend contribution if `--directWebSocket` argument is passed
  - Open direct WebSocket connection from GLSP frontend client to GLSP WebSocket Server
- Fix logLevel argument
- Update README and CHANGELOG

Resolves eclipse-glsp/glsp/issues/984