### PR TITLE
Correctly propagate indeterminate progress

### DIFF
--- a/packages/theia-integration/src/browser/diagram/base-theia-glsp-connector.ts
+++ b/packages/theia-integration/src/browser/diagram/base-theia-glsp-connector.ts
@@ -269,22 +269,24 @@ export abstract class BaseTheiaGLSPConnector implements TheiaGLSPConnector {
     startProgress(widgetId: string, action: StartProgressAction): void {
         const { progressId, title, message, percentage } = action;
         const reporterId = this.progressReporterId(widgetId, progressId);
+        const newPercentage = (percentage ?? -1) >= 0 ? percentage : undefined;
         this.messageService
             .showProgress({ text: title }) //
             .then(progress => {
                 this.progressReporters.set(reporterId, progress);
-                progress.report({ message, work: percentage ? { done: percentage, total: 100 } : undefined });
+                progress.report({ message, work: newPercentage ? { done: newPercentage, total: 100 } : undefined });
             });
     }
 
     updateProgress(widgetId: string, action: UpdateProgressAction): void {
         const { progressId, message, percentage } = action;
+        const newPercentage = (percentage ?? -1) >= 0 ? percentage : undefined;
         const reporterId = this.progressReporterId(widgetId, progressId);
         const progress = this.progressReporters.get(reporterId);
         if (!progress) {
             return;
         }
-        progress.report({ message, work: percentage ? { done: percentage, total: 100 } : undefined });
+        progress.report({ message, work: newPercentage ? { done: newPercentage, total: 100 } : undefined });
     }
 
     endProgress(widgetId: string, action: EndProgressAction): void {


### PR DESCRIPTION
If a server reports a progress of -1 (or <=0) we should forward `undefined` to get an indeterminate progress. This is evident with the Java server, which can't easily specify undefined `int`.

https://github.com/eclipse-glsp/glsp/issues/1019