### PR TITLE
GLSP-1078: Set `additionalSelectionData` property only if data is available

### DIFF
--- a/packages/theia-integration/src/browser/diagram/theia-glsp-selection-forwarder.ts
+++ b/packages/theia-integration/src/browser/diagram/theia-glsp-selection-forwarder.ts
@@ -117,7 +117,7 @@ export class TheiaGLSPSelectionForwarder implements ISelectionListener {
         const additionalSelectionData = (await this.selectionDataService?.getSelectionData(selectedElementsIDs)) ?? undefined;
         const glspSelection: GlspSelection = {
             selectedElementsIDs,
-            additionalSelectionData,
+            ...(additionalSelectionData && { additionalSelectionData }),
             widgetId: this.viewerOptions.baseDiv,
             sourceUri: sourceUri
         };


### PR DESCRIPTION
Only optionally set the `additionalSelectionData` property in the GLSPSelection object. Type check GlspSelection.is(..) allows additionalSelectionData property to be optional, but not with undefined value.

Resolves https://github.com/eclipse-glsp/glsp/issues/1078

Contributed on behalf of STMicroelectronics