### PR TITLE
GLSP-1064: Bugfixes

### DIFF
--- a/packages/theia-integration/src/browser/diagram/glsp-diagram-manager.ts
+++ b/packages/theia-integration/src/browser/diagram/glsp-diagram-manager.ts
@@ -120,10 +120,6 @@ export abstract class GLSPDiagramManager extends WidgetOpenHandler<GLSPDiagramWi
             const config = this.getDiagramConfiguration(options);
             const diagramOptions = this.createDiagramOptions(options);
             const diContainer = config.createContainer(diagramOptions);
-            const glspClientContribution = this.diagramServiceProvider.getGLSPClientContribution(this.contributionId);
-            if (!glspClientContribution) {
-                throw new Error(`No glsp client contribution is registered for id: ${this.contributionId}!`);
-            }
             const diagramWidgetFactory = this.diagramServiceProvider.getDiagramWidgetFactory(this.diagramType);
 
             const widget = diagramWidgetFactory?.create(options, diContainer);

--- a/packages/theia-integration/src/browser/glsp-theia-container-module.ts
+++ b/packages/theia-integration/src/browser/glsp-theia-container-module.ts
@@ -117,7 +117,7 @@ export abstract class GLSPTheiaFrontendModule extends ContainerModule {
      * @param context the container context
      */
     bindDiagramWidgetFactory(context: ContainerContext): void {
-        lazyBind(context, GLSPDiagramWidget)?.toSelf().inSingletonScope();
+        lazyBind(context, GLSPDiagramWidget)?.toSelf();
         context
             .bind(DiagramWidgetFactory)
             .toDynamicValue(ctx => createDiagramWidgetFactory(ctx, this.diagramLanguage.diagramType))

--- a/packages/theia-integration/src/node/glsp-socket-server-contribution.ts
+++ b/packages/theia-integration/src/node/glsp-socket-server-contribution.ts
@@ -267,7 +267,7 @@ export function getPort(argsKey: string, defaultPort?: number): number {
     if (args.length > 0) {
         return Number.parseInt(args[0].substring(argsKey.length), 10);
     }
-    return defaultPort ? defaultPort : NaN;
+    return defaultPort ?? NaN;
 }
 
 /**


### PR DESCRIPTION
- FIxed a bug in widget factory binding that resulted in a single intance of the glsp diagram widget that was reused for alll editors
- Remove unused `glspClientContribution` constant in `GLSPDiagramManager`
- Ensure that the `getPort` utility function does not return `NaN` if the default port 0 is configured

Follow-up for  https://github.com/eclipse-glsp/glsp/issues/1064