### PR TITLE
Guard binding of  generic command contributions

### DIFF
--- a/packages/theia-integration/src/browser/copy-paste-context-menu-contribution.ts
+++ b/packages/theia-integration/src/browser/copy-paste-context-menu-contribution.ts
@@ -16,11 +16,14 @@
 import { bindAsService } from '@eclipse-glsp/client';
 import { MenuContribution, MenuModelRegistry } from '@theia/core';
 import { CommonCommands } from '@theia/core/lib/browser';
-import { injectable, interfaces } from '@theia/core/shared/inversify';
+import { injectable } from '@theia/core/shared/inversify';
+import { ContainerContext } from './glsp-theia-container-module';
 import { TheiaGLSPContextMenu } from './theia-glsp-context-menu-service';
 
-export function registerCopyPasteContextMenu(bind: interfaces.Bind): void {
-    bindAsService(bind, MenuContribution, CopyPasteMenuContribution);
+export function registerCopyPasteContextMenu(context: Omit<ContainerContext, 'unbind' | 'rebind'>): void {
+    if (!context.isBound(CopyPasteMenuContribution)) {
+        bindAsService(context, MenuContribution, CopyPasteMenuContribution);
+    }
 }
 
 @injectable()

--- a/packages/theia-integration/src/browser/diagram/glsp-layout-commands.ts
+++ b/packages/theia-integration/src/browser/diagram/glsp-layout-commands.ts
@@ -24,15 +24,22 @@ import {
 } from '@eclipse-glsp/client';
 import { CommandContribution, CommandRegistry, MenuContribution, MenuModelRegistry, MenuPath } from '@theia/core';
 import { ApplicationShell, KeybindingContribution, KeybindingRegistry } from '@theia/core/lib/browser';
-import { inject, injectable, interfaces } from '@theia/core/shared/inversify';
+import { inject, injectable } from '@theia/core/shared/inversify';
+import { ContainerContext } from '../glsp-theia-container-module';
 import { GLSPCommandHandler } from './glsp-command-handler';
 import { GLSPDiagramMenus } from './glsp-diagram-commands';
 import { GLSPDiagramKeybindingContext } from './glsp-diagram-keybinding';
 
-export function registerDiagramLayoutCommands(bind: interfaces.Bind): void {
-    bindAsService(bind, CommandContribution, GLSPLayoutCommandContribution);
-    bindAsService(bind, MenuContribution, GLSPLayoutMenuContribution);
-    bindAsService(bind, KeybindingContribution, GLSPLayoutKeybindingContribution);
+export function registerDiagramLayoutCommands(context: Omit<ContainerContext, 'unbind' | 'rebind'>): void {
+    if (!context.isBound(GLSPLayoutCommandContribution)) {
+        bindAsService(context, CommandContribution, GLSPLayoutCommandContribution);
+    }
+    if (!context.isBound(GLSPLayoutMenuContribution)) {
+        bindAsService(context, MenuContribution, GLSPLayoutMenuContribution);
+    }
+    if (!context.isBound(GLSPLayoutKeybindingContribution)) {
+        bindAsService(context, KeybindingContribution, GLSPLayoutKeybindingContribution);
+    }
 }
 
 export namespace GLSPLayoutCommands {

--- a/packages/theia-integration/src/browser/glsp-theia-container-module.ts
+++ b/packages/theia-integration/src/browser/glsp-theia-container-module.ts
@@ -171,7 +171,7 @@ export abstract class GLSPTheiaFrontendModule extends ContainerModule {
      */
     configureDiagramLayoutCommands(context: ContainerContext): void {
         if (this.enableLayoutCommands) {
-            registerDiagramLayoutCommands(context.bind);
+            registerDiagramLayoutCommands(context);
         }
     }
 
@@ -184,7 +184,7 @@ export abstract class GLSPTheiaFrontendModule extends ContainerModule {
      */
     configureCopyPasteContextMenu(context: ContainerContext): void {
         if (this.enableCopyPaste) {
-            registerCopyPasteContextMenu(context.bind);
+            registerCopyPasteContextMenu(context);
         }
     }
 
@@ -197,7 +197,7 @@ export abstract class GLSPTheiaFrontendModule extends ContainerModule {
      */
     configureMarkerNavigationCommands(context: ContainerContext): void {
         if (this.enableMarkerNavigationCommands) {
-            registerMarkerNavigationCommands(context.bind);
+            registerMarkerNavigationCommands(context);
         }
     }
 }

--- a/packages/theia-integration/src/browser/theia-navigate-to-marker-contribution.ts
+++ b/packages/theia-integration/src/browser/theia-navigate-to-marker-contribution.ts
@@ -16,13 +16,20 @@
 import { bindAsService, collectIssueMarkers, NavigateToMarkerAction } from '@eclipse-glsp/client/lib';
 import { CommandContribution, CommandRegistry, MenuContribution, MenuModelRegistry } from '@theia/core';
 import { ApplicationShell, KeybindingContribution, KeybindingRegistry } from '@theia/core/lib/browser';
-import { inject, injectable, interfaces } from '@theia/core/shared/inversify';
+import { inject, injectable } from '@theia/core/shared/inversify';
 import { GLSPCommandHandler, GLSPContextMenu, GLSPDiagramKeybindingContext } from './diagram';
+import { ContainerContext } from './glsp-theia-container-module';
 
-export function registerMarkerNavigationCommands(bind: interfaces.Bind): void {
-    bindAsService(bind, CommandContribution, NavigateToMarkerCommandContribution);
-    bindAsService(bind, MenuContribution, NavigateToMarkerMenuContribution);
-    bindAsService(bind, KeybindingContribution, NavigateToMarkerKeybindingContribution);
+export function registerMarkerNavigationCommands(context: Omit<ContainerContext, 'unbind' | 'rebind'>): void {
+    if (!context.isBound(NavigateToMarkerCommandContribution)) {
+        bindAsService(context, CommandContribution, NavigateToMarkerCommandContribution);
+    }
+    if (!context.isBound(NavigateToMarkerMenuContribution)) {
+        bindAsService(context, MenuContribution, NavigateToMarkerMenuContribution);
+    }
+    if (!context.isBound(NavigateToMarkerKeybindingContribution)) {
+        bindAsService(context, KeybindingContribution, NavigateToMarkerKeybindingContribution);
+    }
 }
 
 export namespace NavigateToMarkerCommand {


### PR DESCRIPTION
Ensure that configuring multiple GLSP diagram languages in the Theia frontend does not break the inversify container.
(See also https://github.com/eclipse-glsp/glsp/discussions/1167)

Avoid ambiguous bindings by checking whether the contribution in question is already bound.

Note that this PR only fixes the symptom but not the root cause.
We need a better approach that allows specific enablement of layout/copyPaste or navigation commands per diagram language.
I have openend https://github.com/eclipse-glsp/glsp/issues/1201 to track this.
