### PR TITLE
GLSP-1240: Ensure compatibility with >= Theia 1.44

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,8 +6,8 @@
 {
   "editor.formatOnSave": true,
   "editor.codeActionsOnSave": {
-    "source.organizeImports": true,
-    "source.fixAll.eslint": true
+    "source.organizeImports": "explicit",
+    "source.fixAll.eslint": "explicit"
   },
   "eslint.validate": ["javascript", "typescript"],
   "search.exclude": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Eclipse GLSP Theia Integration Changelog
 
-## 2.1.0 - active
+## [2.1.0- 24/01/2024](https://github.com/eclipse-glsp/glsp-theia-integration/releases/tag/v2.1.0)
 
 ### Changes
 

--- a/README.md
+++ b/README.md
@@ -15,12 +15,12 @@ For details on building the project, please see the [README file of the theia-in
 | 1.0.0                           | >=1.25.0 <= 1.26.0 |
 | 1.0.0-theia1.27.0               | >=1.27.0 < 1.34.0  |
 | 1.0.0-theia1.34.0               | >=1.34.0 < 1.39.0  |
-| 2.0.0                           | >=1.39.0 < 1.44.0  |
-| 2.1.0                           | >=1.39.0 < 1.44.0  |
-| 2.1.0-theia1.44.0               | >=1.44.0           |
-| next                            | >=1.44.0           |
+| 2.0.0                           | >=1.39.0 < 1.45.0  |
+| 2.1.0                           | >=1.39.0 < 1.45.0  |
+| 2.1.0-theia1.45.0               | >=1.45.0           |
+| next                            | >=1.45.0           |
 
-> Note: For versions <=1.0.0 it is not possible to safely restrict the maximum version of Theia packages. If you encounter build errors related to multiple resolved Theia versions please add a resolutions block to the `package.json` of your project e.g. for `1.0.0-theia1.27.0`:
+> Note: For versions =1.0.0 it is not possible to safely restrict the maximum version of Theia packages. If you encounter build errors related to multiple resolved Theia versions please add a resolutions block to the `package.json` of your project e.g. for `1.0.0-theia1.27.0`:
 
 ```json
 ...

--- a/README.md
+++ b/README.md
@@ -8,19 +8,17 @@ For details on building the project, please see the [README file of the theia-in
 
 ## Theia Version Compatibility
 
-The `@eclipse-glsp/theia-integration` package in version `1.0.0` is currently compatible with Theia `>=1.25.0`.
-Theia releases currently have no stable public API so new Theia versions might introduce API breaks.
-If that is the case, a new compatible 1.0.0 version prefixed with the supported minimal Theia version will be released (e.g. `1.0.0-theia1.27.0` for Theia >= 1.27.0).
-
 | @eclipse-glsp/theia-integration | Theia              |
 | ------------------------------- | ------------------ |
 | 0.8.0                           | <=1.4.0            |
 | 0.9.0                           | >=1.20.0 <= 1.25.0 |
 | 1.0.0                           | >=1.25.0 <= 1.26.0 |
-| 1.0.0-theia1.27.0               | >=1.27.0           |
+| 1.0.0-theia1.27.0               | >=1.27.0 < 1.34.0  |
 | 1.0.0-theia1.34.0               | >=1.34.0 < 1.39.0  |
-| 2.0.0                           | >=1.39.0           |
-| next                            | >=1.39.0           |
+| 2.0.0                           | >=1.39.0 < 1.44.0  |
+| 2.1.0                           | >=1.39.0 < 1.44.0  |
+| 2.1.0-theia1.44.0               | >=1.44.0           |
+| next                            | >=1.44.0           |
 
 > Note: For versions <=1.0.0 it is not possible to safely restrict the maximum version of Theia packages. If you encounter build errors related to multiple resolved Theia versions please add a resolutions block to the `package.json` of your project e.g. for `1.0.0-theia1.27.0`:
 

--- a/examples/browser-app/package.json
+++ b/examples/browser-app/package.json
@@ -14,20 +14,20 @@
   },
   "dependencies": {
     "@eclipse-glsp-examples/workflow-theia": "2.2.0-next",
-    "@theia/core": "1.45.0",
-    "@theia/editor": "1.45.0",
-    "@theia/filesystem": "1.45.0",
-    "@theia/markers": "1.45.0",
-    "@theia/messages": "1.45.0",
-    "@theia/monaco": "1.45.0",
-    "@theia/navigator": "1.45.0",
-    "@theia/preferences": "1.45.0",
-    "@theia/process": "1.45.0",
-    "@theia/terminal": "1.45.0",
-    "@theia/workspace": "1.45.0"
+    "@theia/core": "1.45.1",
+    "@theia/editor": "1.45.1",
+    "@theia/filesystem": "1.45.1",
+    "@theia/markers": "1.45.1",
+    "@theia/messages": "1.45.1",
+    "@theia/monaco": "1.45.1",
+    "@theia/navigator": "1.45.1",
+    "@theia/preferences": "1.45.1",
+    "@theia/process": "1.45.1",
+    "@theia/terminal": "1.45.1",
+    "@theia/workspace": "1.45.1"
   },
   "devDependencies": {
-    "@theia/cli": "1.45.0"
+    "@theia/cli": "1.45.1"
   },
   "theia": {
     "target": "browser"

--- a/examples/browser-app/package.json
+++ b/examples/browser-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browser-app",
-  "version": "2.1.0",
+  "version": "2.2.0-next",
   "private": true,
   "scripts": {
     "build": "theia build --mode development",
@@ -13,7 +13,7 @@
     "watch": "theia build --watch --mode development"
   },
   "dependencies": {
-    "@eclipse-glsp-examples/workflow-theia": "2.1.0",
+    "@eclipse-glsp-examples/workflow-theia": "2.2.0-next",
     "@theia/core": "1.39.0",
     "@theia/editor": "1.39.0",
     "@theia/filesystem": "1.39.0",

--- a/examples/browser-app/package.json
+++ b/examples/browser-app/package.json
@@ -14,20 +14,20 @@
   },
   "dependencies": {
     "@eclipse-glsp-examples/workflow-theia": "2.2.0-next",
-    "@theia/core": "1.39.0",
-    "@theia/editor": "1.39.0",
-    "@theia/filesystem": "1.39.0",
-    "@theia/markers": "1.39.0",
-    "@theia/messages": "1.39.0",
-    "@theia/monaco": "1.39.0",
-    "@theia/navigator": "1.39.0",
-    "@theia/preferences": "1.39.0",
-    "@theia/process": "1.39.0",
-    "@theia/terminal": "1.39.0",
-    "@theia/workspace": "1.39.0"
+    "@theia/core": "1.45.0",
+    "@theia/editor": "1.45.0",
+    "@theia/filesystem": "1.45.0",
+    "@theia/markers": "1.45.0",
+    "@theia/messages": "1.45.0",
+    "@theia/monaco": "1.45.0",
+    "@theia/navigator": "1.45.0",
+    "@theia/preferences": "1.45.0",
+    "@theia/process": "1.45.0",
+    "@theia/terminal": "1.45.0",
+    "@theia/workspace": "1.45.0"
   },
   "devDependencies": {
-    "@theia/cli": "1.39.0"
+    "@theia/cli": "1.45.0"
   },
   "theia": {
     "target": "browser"

--- a/examples/workflow-theia/README.md
+++ b/examples/workflow-theia/README.md
@@ -1,24 +1,24 @@
 # workflow-theia
 
-This package contains the glue code to integrate the [GLSP Workflow example language](https://www.npmjs.com/package/@eclipse-glsp-examples/workflow-glsp) into a Theia applicatiopn.
+This package contains the glue code to integrate the [GLSP Workflow example language](https://www.npmjs.com/package/@eclipse-glsp-examples/workflow-glsp) into a Theia application.
 
 This project is built with `yarn` and is available from npm via [@eclipse-glsp-examples/workflow-theia](https://www.npmjs.com/package/@eclipse-glsp-examples/workflow-theia).
 
 ## Theia Version Compatibility
-
-The `@eclipse-glsp/workflow-theia` package in version `1.0.0` is currently compatible with Theia `>=1.25.0`.
-Theia releases currently have no stable public API so new Theia versions might introduce API breaks.
-If that is the case, a new compatible 1.0.0 version prefixed with the supported minimal Theia version will be released (e.g. `1.0.0-theia1.27.0` for Theia >= 1.27.0).
 
 | @eclipse-glsp/theia-integration | Theia              |
 | ------------------------------- | ------------------ |
 | 0.8.0                           | <=1.4.0            |
 | 0.9.0                           | >=1.20.0 <= 1.25.0 |
 | 1.0.0                           | >=1.25.0 <= 1.26.0 |
-| 1.0.0-theia1.27.0               | >=1.27.0           |
-| next                            | >=1.27.0           |
+| 1.0.0-theia1.27.0               | >=1.27.0 < 1.34.0  |
+| 1.0.0-theia1.34.0               | >=1.34.0 < 1.39.0  |
+| 2.0.0                           | >=1.39.0 < 1.45.0  |
+| 2.1.0                           | >=1.39.0 < 1.45.0  |
+| 2.1.0-theia1.45.0               | >=1.45.0           |
+| next                            | >=1.45.0           |
 
-> Note: Due to a transitive dependency to `sprotty-theia` it's currently not possible to safely restrict the maximum version of Theia packages. If you encounter build errors related to multiple resolved Theia versions please add a resolutions block to the `package.json` of your project e.g. for `1.0.0-theia1.27.0`:
+> Note: For versions =1.0.0 it is not possible to safely restrict the maximum version of Theia packages. If you encounter build errors related to multiple resolved Theia versions please add a resolutions block to the `package.json` of your project e.g. for `1.0.0-theia1.27.0`:
 
 ```json
 ...

--- a/examples/workflow-theia/package.json
+++ b/examples/workflow-theia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-glsp-examples/workflow-theia",
-  "version": "2.1.0",
+  "version": "2.2.0-next",
   "private": "true",
   "description": "Theia extension for the workflow GLSP example",
   "keywords": [
@@ -36,10 +36,10 @@
     "watch": "tsc -w"
   },
   "dependencies": {
-    "@eclipse-glsp-examples/workflow-glsp": "2.1.0",
-    "@eclipse-glsp-examples/workflow-server": "2.1.0",
+    "@eclipse-glsp-examples/workflow-glsp": "next",
+    "@eclipse-glsp-examples/workflow-server": "next",
     "@eclipse-glsp-examples/workflow-server-bundled": "next",
-    "@eclipse-glsp/theia-integration": "2.1.0"
+    "@eclipse-glsp/theia-integration": "2.2.0-next"
   },
   "devDependencies": {
     "mvn-artifact-download": "5.1.0"

--- a/packages/theia-integration/README.md
+++ b/packages/theia-integration/README.md
@@ -6,21 +6,19 @@ This project is built with `yarn` and is available from npm via [@eclipse-glsp/t
 
 ## Theia Version Compatibility
 
-The `@eclipse-glsp/theia-integration` package in version `1.0.0` is currently compatible with Theia `>=1.25.0`.
-Theia releases currently have no stable public API so new Theia versions might introduce API breaks.
-If that is the case, a new compatible 1.0.0 version prefixed with the supported minimal Theia version will be released (e.g. `1.0.0-theia1.27.0` for Theia >= 1.27.0).
-
 | @eclipse-glsp/theia-integration | Theia              |
 | ------------------------------- | ------------------ |
 | 0.8.0                           | <=1.4.0            |
 | 0.9.0                           | >=1.20.0 <= 1.25.0 |
 | 1.0.0                           | >=1.25.0 <= 1.26.0 |
-| 1.0.0-theia1.27.0               | >=1.27.0           |
+| 1.0.0-theia1.27.0               | >=1.27.0 < 1.34.0  |
 | 1.0.0-theia1.34.0               | >=1.34.0 < 1.39.0  |
-| 2.0.0                           | >=1.39.0           |
-| next                            | >=1.39.0           |
+| 2.0.0                           | >=1.39.0 < 1.44.0  |
+| 2.1.0                           | >=1.39.0 < 1.44.0  |
+| 2.1.0-theia1.44.0               | >=1.44.0           |
+| next                            | >=1.44.0           |
 
-> Note: Due to a transitive dependency to `sprotty-theia` it's currently not possible to safely restrict the maximum version of Theia packages. If you encounter build errors related to multiple resolved Theia versions please add a resolutions block to the `package.json` of your project e.g. for `1.0.0-theia1.27.0`:
+> Note: For versions =1.0.0 it is not possible to safely restrict the maximum version of Theia packages. If you encounter build errors related to multiple resolved Theia versions please add a resolutions block to the `package.json` of your project e.g. for `1.0.0-theia1.27.0`:
 
 ```json
 ...

--- a/packages/theia-integration/README.md
+++ b/packages/theia-integration/README.md
@@ -13,10 +13,10 @@ This project is built with `yarn` and is available from npm via [@eclipse-glsp/t
 | 1.0.0                           | >=1.25.0 <= 1.26.0 |
 | 1.0.0-theia1.27.0               | >=1.27.0 < 1.34.0  |
 | 1.0.0-theia1.34.0               | >=1.34.0 < 1.39.0  |
-| 2.0.0                           | >=1.39.0 < 1.44.0  |
-| 2.1.0                           | >=1.39.0 < 1.44.0  |
-| 2.1.0-theia1.44.0               | >=1.44.0           |
-| next                            | >=1.44.0           |
+| 2.0.0                           | >=1.39.0 < 1.45.0  |
+| 2.1.0                           | >=1.39.0 < 1.45.0  |
+| 2.1.0-theia1.44.0               | >=1.45.0           |
+| next                            | >=1.45.0           |
 
 > Note: For versions =1.0.0 it is not possible to safely restrict the maximum version of Theia packages. If you encounter build errors related to multiple resolved Theia versions please add a resolutions block to the `package.json` of your project e.g. for `1.0.0-theia1.27.0`:
 

--- a/packages/theia-integration/package.json
+++ b/packages/theia-integration/package.json
@@ -51,10 +51,10 @@
     "@types/ws": "^8.5.4"
   },
   "peerDependencies": {
-    "@theia/core": "^1.39.0",
-    "@theia/filesystem": "^1.39.0",
-    "@theia/messages": "^1.39.0",
-    "@theia/monaco": "^1.39.0"
+    "@theia/core": "^1.44.0",
+    "@theia/filesystem": "^1.44.0",
+    "@theia/messages": "^1.44.0",
+    "@theia/monaco": "^1.44.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/theia-integration/package.json
+++ b/packages/theia-integration/package.json
@@ -51,10 +51,10 @@
     "@types/ws": "^8.5.4"
   },
   "peerDependencies": {
-    "@theia/core": "^1.44.0",
-    "@theia/filesystem": "^1.44.0",
-    "@theia/messages": "^1.44.0",
-    "@theia/monaco": "^1.44.0"
+    "@theia/core": "^1.45.1",
+    "@theia/filesystem": "^1.45.1",
+    "@theia/messages": "^1.45.1",
+    "@theia/monaco": "^1.45.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/theia-integration/package.json
+++ b/packages/theia-integration/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-glsp/theia-integration",
-  "version": "2.1.0",
+  "version": "2.2.0-next",
   "description": "Glue code to integrate GLSP clients into Eclipse Theia",
   "keywords": [
     "theia-extension",
@@ -44,7 +44,7 @@
     "watch": "tsc -w"
   },
   "dependencies": {
-    "@eclipse-glsp/client": "2.1.0",
+    "@eclipse-glsp/client": "next",
     "ws": "~8.11.0"
   },
   "devDependencies": {

--- a/packages/theia-integration/src/browser/theia-integration-frontend-module.ts
+++ b/packages/theia-integration/src/browser/theia-integration-frontend-module.ts
@@ -15,12 +15,8 @@
  ********************************************************************************/
 import { bindAsService } from '@eclipse-glsp/client';
 import { CommandContribution, MenuContribution, bindContributionProvider } from '@theia/core';
-import {
-    FrontendApplicationContribution,
-    KeybindingContext,
-    KeybindingContribution,
-    WebSocketConnectionProvider
-} from '@theia/core/lib/browser';
+import { FrontendApplicationContribution, KeybindingContext, KeybindingContribution } from '@theia/core/lib/browser';
+import { ServiceConnectionProvider } from '@theia/core/lib/browser/messaging/service-connection-provider';
 import { ContainerModule } from '@theia/core/shared/inversify';
 import { GLSPContribution } from '../common';
 import { DiagramServiceProvider } from './diagram-service-provider';
@@ -43,7 +39,7 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
     bindAsService(context, FrontendApplicationContribution, GLSPFrontendContribution);
     bind(DiagramServiceProvider).toSelf().inSingletonScope();
     bind(GLSPContribution.Service)
-        .toDynamicValue(({ container }) => WebSocketConnectionProvider.createProxy(container, GLSPContribution.servicePath))
+        .toDynamicValue(({ container }) => ServiceConnectionProvider.createProxy(container, GLSPContribution.servicePath))
         .inSingletonScope();
 
     // Diagram Command API

--- a/packages/theia-integration/src/node/glsp-backend-contribution.ts
+++ b/packages/theia-integration/src/node/glsp-backend-contribution.ts
@@ -43,7 +43,7 @@ export class GLSPBackendContribution implements MessagingService.Contribution {
     }
 
     protected forward(service: MessagingService, path: string, contribution: GLSPServerContribution): void {
-        service.wsChannel(path, async (_params, clientChannel) => {
+        service.registerChannelHandler(path, async (_params, clientChannel) => {
             try {
                 const toDispose = await contribution.connect(clientChannel);
                 clientChannel.onClose(() => toDispose.dispose());

--- a/yarn.lock
+++ b/yarn.lock
@@ -1399,35 +1399,35 @@
   dependencies:
     cross-spawn "^7.0.1"
 
-"@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.2":
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.2.tgz#44d752c1a2dc113f15f781b7cc4f53a307e3fa38"
-  integrity sha512-9bfjwDxIDWmmOKusUcqdS4Rw+SETlp9Dy39Xui9BEGEk19dDwH0jhipwFzEff/pFg95NKymc6TOTbRKcWeRqyQ==
+"@msgpackr-extract/msgpackr-extract-darwin-arm64@2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-2.2.0.tgz#901c5937e1441572ea23e631fe6deca68482fe76"
+  integrity sha512-Z9LFPzfoJi4mflGWV+rv7o7ZbMU5oAU9VmzCgL240KnqDW65Y2HFCT3MW06/ITJSnbVLacmcEJA8phywK7JinQ==
 
-"@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.2":
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.2.tgz#f954f34355712212a8e06c465bc06c40852c6bb3"
-  integrity sha512-lwriRAHm1Yg4iDf23Oxm9n/t5Zpw1lVnxYU3HnJPTi2lJRkKTrps1KVgvL6m7WvmhYVt/FIsssWay+k45QHeuw==
+"@msgpackr-extract/msgpackr-extract-darwin-x64@2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-2.2.0.tgz#fb877fe6bae3c4d3cea29786737840e2ae689066"
+  integrity sha512-vq0tT8sjZsy4JdSqmadWVw6f66UXqUCabLmUVHZwUFzMgtgoIIQjT4VVRHKvlof3P/dMCkbMJ5hB1oJ9OWHaaw==
 
-"@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.2":
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.2.tgz#45c63037f045c2b15c44f80f0393fa24f9655367"
-  integrity sha512-FU20Bo66/f7He9Fp9sP2zaJ1Q8L9uLPZQDub/WlUip78JlPeMbVL8546HbZfcW9LNciEXc8d+tThSJjSC+tmsg==
+"@msgpackr-extract/msgpackr-extract-linux-arm64@2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-2.2.0.tgz#986179c38b10ac41fbdaf7d036c825cbc72855d9"
+  integrity sha512-hlxxLdRmPyq16QCutUtP8Tm6RDWcyaLsRssaHROatgnkOxdleMTgetf9JsdncL8vLh7FVy/RN9i3XR5dnb9cRA==
 
-"@msgpackr-extract/msgpackr-extract-linux-arm@3.0.2":
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.2.tgz#35707efeafe6d22b3f373caf9e8775e8920d1399"
-  integrity sha512-MOI9Dlfrpi2Cuc7i5dXdxPbFIgbDBGgKR5F2yWEa6FVEtSWncfVNKW5AKjImAQ6CZlBK9tympdsZJ2xThBiWWA==
+"@msgpackr-extract/msgpackr-extract-linux-arm@2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-2.2.0.tgz#15f2c6fe9e0adc06c21af7e95f484ff4880d79ce"
+  integrity sha512-SaJ3Qq4lX9Syd2xEo9u3qPxi/OB+5JO/ngJKK97XDpa1C587H9EWYO6KD8995DAjSinWvdHKRrCOXVUC5fvGOg==
 
-"@msgpackr-extract/msgpackr-extract-linux-x64@3.0.2":
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.2.tgz#091b1218b66c341f532611477ef89e83f25fae4f"
-  integrity sha512-gsWNDCklNy7Ajk0vBBf9jEx04RUxuDQfBse918Ww+Qb9HCPoGzS+XJTLe96iN3BVK7grnLiYghP/M4L8VsaHeA==
+"@msgpackr-extract/msgpackr-extract-linux-x64@2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-2.2.0.tgz#30cae5c9a202f3e1fa1deb3191b18ffcb2f239a2"
+  integrity sha512-94y5PJrSOqUNcFKmOl7z319FelCLAE0rz/jPCWS+UtdMZvpa4jrQd+cJPQCLp2Fes1yAW/YUQj/Di6YVT3c3Iw==
 
-"@msgpackr-extract/msgpackr-extract-win32-x64@3.0.2":
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.2.tgz#0f164b726869f71da3c594171df5ebc1c4b0a407"
-  integrity sha512-O+6Gs8UeDbyFpbSh2CPEz/UOrrdWPTBYNblZK5CxxLisYt4kGX3Sc+czffFonyjiGSq3jWLwJS/CCJc7tBr4sQ==
+"@msgpackr-extract/msgpackr-extract-win32-x64@2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-2.2.0.tgz#016d855b6bc459fd908095811f6826e45dd4ba64"
+  integrity sha512-XrC0JzsqQSvOyM3t04FMLO6z5gCuhPE6k4FXuLK5xf52ZbdvcFe1yBmo7meCew9B8G2f0T9iu9t3kfTYRYROgA==
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -1836,20 +1836,6 @@
     picocolors "^1.0.0"
     tslib "^2.6.0"
 
-"@puppeteer/browsers@0.5.0":
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/@puppeteer/browsers/-/browsers-0.5.0.tgz#1a1ee454b84a986b937ca2d93146f25a3fe8b670"
-  integrity sha512-Uw6oB7VvmPRLE4iKsjuOh8zgDabhNX67dzo8U/BB0f9527qx+4eeUs+korU98OhG5C4ubg7ufBgVi63XYwS6TQ==
-  dependencies:
-    debug "4.3.4"
-    extract-zip "2.0.1"
-    https-proxy-agent "5.0.1"
-    progress "2.0.3"
-    proxy-from-env "1.1.0"
-    tar-fs "2.1.1"
-    unbzip2-stream "1.4.3"
-    yargs "17.7.1"
-
 "@sigstore/bundle@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@sigstore/bundle/-/bundle-1.1.0.tgz#17f8d813b09348b16eeed66a8cf1c3d6bd3d04f1"
@@ -1953,20 +1939,20 @@
   dependencies:
     defer-to-connect "^2.0.0"
 
-"@theia/application-manager@1.39.0":
-  version "1.39.0"
-  resolved "https://registry.yarnpkg.com/@theia/application-manager/-/application-manager-1.39.0.tgz#5a6ffd959754d17f47c125029ac4f76ba0ab3377"
-  integrity sha512-XgZQLRyr1Ty/xyiD2HvaL3+DeF6R/yXfgu85tTOD0wKVjRqSqI/5iSv0EBspdJUCxuVDrmQT4jBnRsXTDhixvA==
+"@theia/application-manager@1.45.0":
+  version "1.45.0"
+  resolved "https://registry.yarnpkg.com/@theia/application-manager/-/application-manager-1.45.0.tgz#b51c4598a349e475d20c03a1477a8277ae3e084d"
+  integrity sha512-m5ikhVCTtWVB6ZznGWCpQDHE/lWsCRhEaYcneCABcny7QBDz64YOBQWZ1MATwAtedeQ6uPT0rL6bdtrYC6N+vA==
   dependencies:
     "@babel/core" "^7.10.0"
     "@babel/plugin-transform-classes" "^7.10.0"
     "@babel/plugin-transform-runtime" "^7.10.0"
     "@babel/preset-env" "^7.10.0"
-    "@theia/application-package" "1.39.0"
-    "@theia/ffmpeg" "1.39.0"
-    "@theia/native-webpack-plugin" "1.39.0"
+    "@theia/application-package" "1.45.0"
+    "@theia/ffmpeg" "1.45.0"
+    "@theia/native-webpack-plugin" "1.45.0"
     "@types/fs-extra" "^4.0.2"
-    "@types/semver" "^7.3.8"
+    "@types/semver" "^7.5.0"
     babel-loader "^8.2.2"
     buffer "^6.0.3"
     compression-webpack-plugin "^9.0.0"
@@ -1980,7 +1966,7 @@
     node-abi "*"
     node-loader "^2.0.0"
     path-browserify "^1.0.1"
-    semver "^7.3.5"
+    semver "^7.5.4"
     setimmediate "^1.0.5"
     source-map "^0.6.1"
     source-map-loader "^2.0.1"
@@ -1993,38 +1979,38 @@
     worker-loader "^3.0.8"
     yargs "^15.3.1"
 
-"@theia/application-package@1.39.0":
-  version "1.39.0"
-  resolved "https://registry.yarnpkg.com/@theia/application-package/-/application-package-1.39.0.tgz#e8ec34d47c059ea8215f24e8cf8b8ad7d1445c6d"
-  integrity sha512-5IP9DavsspA3wUo0P0Cds1ESFtJGl+7LCZnMwCl06xVJYyrii7IQ7CDy8FmG0iDZF0bFDwOwTnRgI61YqAjx3g==
+"@theia/application-package@1.45.0":
+  version "1.45.0"
+  resolved "https://registry.yarnpkg.com/@theia/application-package/-/application-package-1.45.0.tgz#47c6cd35e0143afa263d51db5c0b7114872e44b0"
+  integrity sha512-14unjOa0yKjJ70fWxuz27shdDbdAqDcH09TmM2WHByIgVGu3CfhJaH77FPevf0DBu1A+Z2280ulCKD89+rb9TA==
   dependencies:
-    "@theia/request" "1.39.0"
+    "@theia/request" "1.45.0"
     "@types/fs-extra" "^4.0.2"
-    "@types/semver" "^5.4.0"
+    "@types/semver" "^7.5.0"
     "@types/write-json-file" "^2.2.1"
     deepmerge "^4.2.2"
     fs-extra "^4.0.2"
     is-electron "^2.1.0"
     nano "^9.0.5"
     resolve-package-path "^4.0.3"
-    semver "^5.4.1"
+    semver "^7.5.4"
     write-json-file "^2.2.0"
 
-"@theia/cli@1.39.0":
-  version "1.39.0"
-  resolved "https://registry.yarnpkg.com/@theia/cli/-/cli-1.39.0.tgz#7a304f7e622206dbe5b846431bfa8c582c8d4121"
-  integrity sha512-gYZY16dr+49hO0r1WqwHYkxR/rJ75NUtaqUa6QyO/And4QjTMvZCC1u3RAg6yLWR5NyLdd7hhRtzb8fb9kWcOA==
+"@theia/cli@1.45.0":
+  version "1.45.0"
+  resolved "https://registry.yarnpkg.com/@theia/cli/-/cli-1.45.0.tgz#4563703371f1eb2cde960284481d7360181e58c5"
+  integrity sha512-k5IS3bhks3WPZ9w2qPojIhNfE5wgXs6AtW/XOwResYeLXWxRCpsiooX0Rj/IcJKN7hJZiu7dk0R5QhG7shsiIw==
   dependencies:
-    "@theia/application-manager" "1.39.0"
-    "@theia/application-package" "1.39.0"
-    "@theia/ffmpeg" "1.39.0"
-    "@theia/localization-manager" "1.39.0"
-    "@theia/ovsx-client" "1.39.0"
-    "@theia/request" "1.39.0"
+    "@theia/application-manager" "1.45.0"
+    "@theia/application-package" "1.45.0"
+    "@theia/ffmpeg" "1.45.0"
+    "@theia/localization-manager" "1.45.0"
+    "@theia/ovsx-client" "1.45.0"
+    "@theia/request" "1.45.0"
     "@types/chai" "^4.2.7"
     "@types/mocha" "^10.0.0"
     "@types/node-fetch" "^2.5.7"
-    chai "^4.2.0"
+    chai "^4.3.10"
     chalk "4.0.0"
     decompress "^4.2.1"
     escape-string-regexp "4.0.0"
@@ -2032,16 +2018,16 @@
     limiter "^2.1.0"
     log-update "^4.0.0"
     mocha "^10.1.0"
-    puppeteer "^19.7.2"
-    puppeteer-core "^19.7.2"
-    puppeteer-to-istanbul "^1.4.0"
+    puppeteer "19.7.2"
+    puppeteer-core "19.7.2"
+    puppeteer-to-istanbul "1.4.0"
     temp "^0.9.1"
     yargs "^15.3.1"
 
-"@theia/core@1.39.0":
-  version "1.39.0"
-  resolved "https://registry.yarnpkg.com/@theia/core/-/core-1.39.0.tgz#34bf07edce5e4e90ef0578acca46e51ce07450fc"
-  integrity sha512-EmvIpp3mKGSFO50iOm3hOa66WlyHigFOGyq1N4nVibzb82/T065LZDof8NTLXl50cMr6H3ZFhBC32TTGf4ircw==
+"@theia/core@1.45.0":
+  version "1.45.0"
+  resolved "https://registry.yarnpkg.com/@theia/core/-/core-1.45.0.tgz#f0a2c36ccb89cf38d4717ef1a58b4c83ccefe41d"
+  integrity sha512-7kTkDKxSX+IO0j/gWVphWZTXLv1pHSk4R5NlSIfDJapnLWU8F3l0uJSmwqw5T1V+WxMCJYnVai+DCm7h3kQoyw==
   dependencies:
     "@babel/runtime" "^7.10.0"
     "@phosphor/algorithm" "1"
@@ -2054,8 +2040,8 @@
     "@phosphor/signaling" "1"
     "@phosphor/virtualdom" "1"
     "@phosphor/widgets" "1"
-    "@theia/application-package" "1.39.0"
-    "@theia/request" "1.39.0"
+    "@theia/application-package" "1.45.0"
+    "@theia/request" "1.45.0"
     "@types/body-parser" "^1.16.4"
     "@types/cookie" "^0.3.3"
     "@types/dompurify" "^2.2.2"
@@ -2068,7 +2054,7 @@
     "@types/react-dom" "^18.0.6"
     "@types/route-parser" "^0.1.1"
     "@types/safer-buffer" "^2.1.0"
-    "@types/ws" "^5.1.2"
+    "@types/ws" "^8.5.5"
     "@types/yargs" "^15"
     "@vscode/codicons" "*"
     ajv "^6.5.3"
@@ -2093,7 +2079,7 @@
     lodash.debounce "^4.0.8"
     lodash.throttle "^4.1.1"
     markdown-it "^12.3.2"
-    msgpackr "^1.6.1"
+    msgpackr "1.6.1"
     nsfw "^2.2.4"
     p-debounce "^2.1.0"
     perfect-scrollbar "^1.3.0"
@@ -2109,31 +2095,31 @@
     uuid "^8.3.2"
     vscode-languageserver-protocol "^3.17.2"
     vscode-uri "^2.1.1"
-    ws "^7.1.2"
+    ws "^8.14.1"
     yargs "^15.3.1"
 
-"@theia/editor@1.39.0":
-  version "1.39.0"
-  resolved "https://registry.yarnpkg.com/@theia/editor/-/editor-1.39.0.tgz#ef083070b254a03dd2899975b455abbcc5dbac66"
-  integrity sha512-CX/Ttl48H0ZKfNq+am/lSYwzDk+y+Ok6nmgqlZ39OpwrHH6z57VvKX+GpRSFBsT8IxWRRlscx2hoBW0yURRVlQ==
+"@theia/editor@1.45.0":
+  version "1.45.0"
+  resolved "https://registry.yarnpkg.com/@theia/editor/-/editor-1.45.0.tgz#4f43c25705ef71bef33c7875bafe86402446cc64"
+  integrity sha512-ifh+V1xng3PbsI05PkZDBBqtiNhiAxag1DlNYDaI7BqfEJ/OoJVJrKzrDr7JXIhLaK/UQNb+tk3OPdqLrJFRiA==
   dependencies:
-    "@theia/core" "1.39.0"
-    "@theia/variable-resolver" "1.39.0"
+    "@theia/core" "1.45.0"
+    "@theia/variable-resolver" "1.45.0"
 
-"@theia/ffmpeg@1.39.0":
-  version "1.39.0"
-  resolved "https://registry.yarnpkg.com/@theia/ffmpeg/-/ffmpeg-1.39.0.tgz#0b82b0aa876018286fed3a71dbcf9fcc56ad1c83"
-  integrity sha512-TegG0fsEuvHbqLVr+NbkSsb/PzCXBM1RdowJhtkvTfSqZRW5dIWwA0KcojrPR5In+67Nv+BC+7kQAIlh4DXyPg==
+"@theia/ffmpeg@1.45.0":
+  version "1.45.0"
+  resolved "https://registry.yarnpkg.com/@theia/ffmpeg/-/ffmpeg-1.45.0.tgz#34ed4f08d5acb596ad0ce973baa920b3005cacbe"
+  integrity sha512-qDi91J5Md/NiFgm4xd+JMZ6W4yLWQH0rmgZOUrBpdQVZ0AWiS1DZhXQtD0DQNK45Om4LZTDjfXNEDezK9XFbGA==
   dependencies:
     "@electron/get" "^2.0.0"
     unzipper "^0.9.11"
 
-"@theia/filesystem@1.39.0":
-  version "1.39.0"
-  resolved "https://registry.yarnpkg.com/@theia/filesystem/-/filesystem-1.39.0.tgz#e031d4b6e8eb6a43422844e32c1e64e2a301e70b"
-  integrity sha512-dhS/xMqeJ1rjmznw2v3BYt28U/ETAhrjw3DeWDSheNalIobTXEc3oCUpSgameNHDVrehpA47cYGwOTymHYfcrg==
+"@theia/filesystem@1.45.0":
+  version "1.45.0"
+  resolved "https://registry.yarnpkg.com/@theia/filesystem/-/filesystem-1.45.0.tgz#b3637c4ce6b9a11b0982a4d21aecb149102f4409"
+  integrity sha512-rwc+epRpF4G7cmpaD1pLNH0UBPikz4p+EydV3YWC70t8izXzvv6DPqQ4JtrZzqUuOmH25pomSxYkBj/KRgyW0g==
   dependencies:
-    "@theia/core" "1.39.0"
+    "@theia/core" "1.45.0"
     "@types/body-parser" "^1.17.0"
     "@types/multer" "^1.4.7"
     "@types/rimraf" "^2.0.2"
@@ -2145,15 +2131,16 @@
     minimatch "^5.1.0"
     multer "1.4.4-lts.1"
     rimraf "^2.6.2"
+    stat-mode "^1.0.0"
     tar-fs "^1.16.2"
     trash "^7.2.0"
     uuid "^8.0.0"
     vscode-languageserver-textdocument "^1.0.1"
 
-"@theia/localization-manager@1.39.0":
-  version "1.39.0"
-  resolved "https://registry.yarnpkg.com/@theia/localization-manager/-/localization-manager-1.39.0.tgz#4752b49b93f0de2c6e9aa8e121e5cf251ba7d021"
-  integrity sha512-RlUBmInrIhigd24kxpF8qeLcswA2QiWMXDqgQkOG6ZYfZ86aMpka6xBn6s32ijOpUwmhU7VOkFm0Zxf0DwBhEg==
+"@theia/localization-manager@1.45.0":
+  version "1.45.0"
+  resolved "https://registry.yarnpkg.com/@theia/localization-manager/-/localization-manager-1.45.0.tgz#a9ba5fb5b8a3936dfb2b5cc623c8c4976acbbeff"
+  integrity sha512-JvOkOmduD8mUCmiwe2ezlIUuJXMwDWrYxQ5UvIOINmoWDxy6chpFy1k2ZbjYYO3k3rWgR9YsdWPbf9NmzXuB7w==
   dependencies:
     "@types/bent" "^7.0.1"
     "@types/fs-extra" "^4.0.2"
@@ -2164,21 +2151,21 @@
     glob "^7.2.0"
     typescript "~4.5.5"
 
-"@theia/markers@1.39.0":
-  version "1.39.0"
-  resolved "https://registry.yarnpkg.com/@theia/markers/-/markers-1.39.0.tgz#b196d4f275e98c1ee6465c195e433068bb749048"
-  integrity sha512-Eu87s02CjmBLO615wUvN8CTRltjbHVwYTT+hs9y+pVXjhlhfpswM4P9MQxIOx8XDSoL2D00VasIybwdq3hHQGQ==
+"@theia/markers@1.45.0":
+  version "1.45.0"
+  resolved "https://registry.yarnpkg.com/@theia/markers/-/markers-1.45.0.tgz#e54b474b8cef5b061b17282202121663474cc09c"
+  integrity sha512-pxMu7eu0gzcrY5ec7r9kmMZlKzqy9y2lM7/T9yBGs4EO1iCK1mrBEaf5KJ7MnH44mDfvf7zSME8VfCrOg8JVrw==
   dependencies:
-    "@theia/core" "1.39.0"
-    "@theia/filesystem" "1.39.0"
-    "@theia/workspace" "1.39.0"
+    "@theia/core" "1.45.0"
+    "@theia/filesystem" "1.45.0"
+    "@theia/workspace" "1.45.0"
 
-"@theia/messages@1.39.0":
-  version "1.39.0"
-  resolved "https://registry.yarnpkg.com/@theia/messages/-/messages-1.39.0.tgz#6845a448227abf6eb71f5f3a29a7fde1d1e595f0"
-  integrity sha512-FAUeNjssuH1Xf/uGPs6f0XJijBULflAy5iJXL5qDkZQkH+cWLJsy+1QrsRN5nxg8Cw6HUDt96Oe8DMwsYkdqRQ==
+"@theia/messages@1.45.0":
+  version "1.45.0"
+  resolved "https://registry.yarnpkg.com/@theia/messages/-/messages-1.45.0.tgz#63eb9e9b5c7356a84b82eea202c0a031b49a1358"
+  integrity sha512-QdsGGRIeZBi6VNsR4rzFw5v1O4xYwfmwEoOUCXWE3gjoqEyyJvCyUehjHPke/5IVyGuYyO0NL9SsuxodF5gUvw==
   dependencies:
-    "@theia/core" "1.39.0"
+    "@theia/core" "1.45.0"
     react-perfect-scrollbar "^1.5.3"
     ts-md5 "^1.2.2"
 
@@ -2187,128 +2174,128 @@
   resolved "https://registry.yarnpkg.com/@theia/monaco-editor-core/-/monaco-editor-core-1.72.3.tgz#911d674c6e0c490442a355cfaa52beec919a025e"
   integrity sha512-2FK5m0G5oxiqCv0ZrjucMx5fVgQ9Jqv0CgxGvSzDc4wRrauBdeBoX90J99BEIOJ8Jp3W0++GoRBdh0yQNIGL2g==
 
-"@theia/monaco@1.39.0":
-  version "1.39.0"
-  resolved "https://registry.yarnpkg.com/@theia/monaco/-/monaco-1.39.0.tgz#b1943d4d94022969c3401711a45f08b497520625"
-  integrity sha512-fbEC27l7H0D8D968J6i+wn5wFMsmbGQpYOt/fPGdda7cCxxYlb7vy3krYbDn8EvHRMEF+2OCVydcOF41u81RxA==
+"@theia/monaco@1.45.0":
+  version "1.45.0"
+  resolved "https://registry.yarnpkg.com/@theia/monaco/-/monaco-1.45.0.tgz#64d3a7a0f4177715e2753d9c88e14b5709932fa5"
+  integrity sha512-6qzLGLyy81K4yFjJ848CQ0in63nymF1nV+tSCYt8yz3r/GIYxVnzaxgZ1PsC76BjH+FxgZxN/U3TgssY/9SP/Q==
   dependencies:
-    "@theia/core" "1.39.0"
-    "@theia/editor" "1.39.0"
-    "@theia/filesystem" "1.39.0"
-    "@theia/markers" "1.39.0"
+    "@theia/core" "1.45.0"
+    "@theia/editor" "1.45.0"
+    "@theia/filesystem" "1.45.0"
+    "@theia/markers" "1.45.0"
     "@theia/monaco-editor-core" "1.72.3"
-    "@theia/outline-view" "1.39.0"
+    "@theia/outline-view" "1.45.0"
+    "@theia/workspace" "1.45.0"
     fast-plist "^0.1.2"
     idb "^4.0.5"
     jsonc-parser "^2.2.0"
     vscode-oniguruma "1.6.1"
-    vscode-textmate "^7.0.3"
+    vscode-textmate "^9.0.0"
 
-"@theia/native-webpack-plugin@1.39.0":
-  version "1.39.0"
-  resolved "https://registry.yarnpkg.com/@theia/native-webpack-plugin/-/native-webpack-plugin-1.39.0.tgz#3945a414d567d39448a6853feab97a637c3f1927"
-  integrity sha512-SOm8bBHjkHtKfocoA5pfz7b3c07SUVQWpd9JQnxDVETsVnBE64T/sEVtuR/JWMHSH5I+Znx4mQ47/vmsBNLGQQ==
+"@theia/native-webpack-plugin@1.45.0":
+  version "1.45.0"
+  resolved "https://registry.yarnpkg.com/@theia/native-webpack-plugin/-/native-webpack-plugin-1.45.0.tgz#95421566084249d2bd40ac8089947eb1f5f8b8d3"
+  integrity sha512-ISSMJpkPZFVWcH4kr1ASyp55VRbrh8dSo0eZ0Zv9CU0axtspDtYE5dc3HzGwsp7F+aARtSDpoAFXKDqD0Ybsxg==
   dependencies:
-    temp "^0.9.1"
     webpack "^5.76.0"
 
-"@theia/navigator@1.39.0":
-  version "1.39.0"
-  resolved "https://registry.yarnpkg.com/@theia/navigator/-/navigator-1.39.0.tgz#b76a6cf72d691576a385905499e673e39f41ef9a"
-  integrity sha512-4AET4BOrEdZ/kmADL0n8hm6iTy0rA7QaqwkNJfSNxW1fNkLmnfZ4zkAGb7G7z7NEAiT8x6+HkiOKxcRqm1F/jA==
+"@theia/navigator@1.45.0":
+  version "1.45.0"
+  resolved "https://registry.yarnpkg.com/@theia/navigator/-/navigator-1.45.0.tgz#23d1cc8345a1b6d68de85c676b8b7cd2ab217061"
+  integrity sha512-nkpeSChHZQPIEIL0EQYSqnh8krqknh/jTB3ThZnH9AfH8r6iccpz/d1bPaoAoR9fyufXRIZqg7gLCbp4whpjIA==
   dependencies:
-    "@theia/core" "1.39.0"
-    "@theia/filesystem" "1.39.0"
-    "@theia/workspace" "1.39.0"
+    "@theia/core" "1.45.0"
+    "@theia/filesystem" "1.45.0"
+    "@theia/workspace" "1.45.0"
     minimatch "^5.1.0"
 
-"@theia/outline-view@1.39.0":
-  version "1.39.0"
-  resolved "https://registry.yarnpkg.com/@theia/outline-view/-/outline-view-1.39.0.tgz#1b4a9032730164f646dbd0d7a8b4d94b38a6d9bc"
-  integrity sha512-zFwxWsJmSFUxnZyC+NwWcq1P7XOOLl0or30jSZGXgIvLVBVL/5QT8Uiaxi750SpAPCl4S1zfGYYXaGWqcj2YCg==
+"@theia/outline-view@1.45.0":
+  version "1.45.0"
+  resolved "https://registry.yarnpkg.com/@theia/outline-view/-/outline-view-1.45.0.tgz#b850599ed8f7e346cf2e0c539f627d613663fb0b"
+  integrity sha512-PiXmBLe8LRk/jMLWs+51SdA7WhTky6OsIylLQ726SI60h0STie9NoLP3MvkNHC120yaQUbJm3x3L/m4yjF/wVw==
   dependencies:
-    "@theia/core" "1.39.0"
+    "@theia/core" "1.45.0"
 
-"@theia/ovsx-client@1.39.0":
-  version "1.39.0"
-  resolved "https://registry.yarnpkg.com/@theia/ovsx-client/-/ovsx-client-1.39.0.tgz#4dd3929c7ee05687fd9655a6f37ea6039c943d69"
-  integrity sha512-vfIAHbt66D0sbujQrQxg0KbIBU0nXexVwluHhpn9m28fgkRA+4lvNvAu0iIHu2OTWniO4CJvBzOyiALbSG10rQ==
+"@theia/ovsx-client@1.45.0":
+  version "1.45.0"
+  resolved "https://registry.yarnpkg.com/@theia/ovsx-client/-/ovsx-client-1.45.0.tgz#bfc7d3fefe5db66779559e740f316ef367908470"
+  integrity sha512-oguhhJNpwNyesNZRrRWYGfVCGRe6HQkvf+SdaUN4LvJwC4jXF82/OOolU6VptcPzsrDH/mFPAMVfL78o2W9vcQ==
   dependencies:
-    "@theia/request" "1.39.0"
-    semver "^5.4.1"
+    "@theia/request" "1.45.0"
+    semver "^7.5.4"
 
-"@theia/preferences@1.39.0":
-  version "1.39.0"
-  resolved "https://registry.yarnpkg.com/@theia/preferences/-/preferences-1.39.0.tgz#4c7228fc646b85c5b9f8ede448820d4f312cc3b5"
-  integrity sha512-abO0EwpmyOD0DBRk1ReXF7jLd7aDjx5Und9tLbggrZs4dDpNsIvED5axwkA+mRTlq3gdnnVRCbBqP5HZQ3LxFA==
+"@theia/preferences@1.45.0":
+  version "1.45.0"
+  resolved "https://registry.yarnpkg.com/@theia/preferences/-/preferences-1.45.0.tgz#5b377b8238656fa57914976bb0d34c22d92ae06c"
+  integrity sha512-BPL5Kbg1s7q0Vx+9vYBqD2njjmOVTXYSPDh6MKx/I73e85TlxCCUfFh/TqmcFmS1OMIgYg5PwMvDGNP6bbv44g==
   dependencies:
-    "@theia/core" "1.39.0"
-    "@theia/editor" "1.39.0"
-    "@theia/filesystem" "1.39.0"
-    "@theia/monaco" "1.39.0"
+    "@theia/core" "1.45.0"
+    "@theia/editor" "1.45.0"
+    "@theia/filesystem" "1.45.0"
+    "@theia/monaco" "1.45.0"
     "@theia/monaco-editor-core" "1.72.3"
-    "@theia/userstorage" "1.39.0"
-    "@theia/workspace" "1.39.0"
+    "@theia/userstorage" "1.45.0"
+    "@theia/workspace" "1.45.0"
     async-mutex "^0.3.1"
     fast-deep-equal "^3.1.3"
     jsonc-parser "^2.2.0"
     p-debounce "^2.1.0"
 
-"@theia/process@1.39.0":
-  version "1.39.0"
-  resolved "https://registry.yarnpkg.com/@theia/process/-/process-1.39.0.tgz#5b0d4fb5ade9f8d550aab998d794a8645de0a141"
-  integrity sha512-Jm/pSNDshT09sS6GqQzRYQv7wArE7m31h7UoRksIsgVQM3xNmFOM080hkNhvvM3rTj6yGAVux5qfFZSXqBiAsg==
+"@theia/process@1.45.0":
+  version "1.45.0"
+  resolved "https://registry.yarnpkg.com/@theia/process/-/process-1.45.0.tgz#a5e6bd01ecfe5a644028e50ee1edc34e23db9881"
+  integrity sha512-RRqt6KmLc4ahO5+pEBrfFYnBwp+NlUXLarfT6nnUP+ILGPJpMf5S65xGecrz0BLRynDV9E9d4xyAXE1gYYS9fA==
   dependencies:
-    "@theia/core" "1.39.0"
+    "@theia/core" "1.45.0"
     node-pty "0.11.0-beta17"
     string-argv "^0.1.1"
 
-"@theia/request@1.39.0":
-  version "1.39.0"
-  resolved "https://registry.yarnpkg.com/@theia/request/-/request-1.39.0.tgz#961fcfa5912232d26958a7de55e93c959a8c0a74"
-  integrity sha512-kDfys8mVIgbVNCdgx/rDm1harEmhO3I1gNfJE49ysS1mfyKqKifpthtnEZRQha0za9hHyUG+eVIbx2Xhf4vBIg==
+"@theia/request@1.45.0":
+  version "1.45.0"
+  resolved "https://registry.yarnpkg.com/@theia/request/-/request-1.45.0.tgz#f16ed97a488dacdbb62532c3743af5da49ffb15b"
+  integrity sha512-wAu69y3XFoCLWp2aZA5jFM+P7K9dOjzinE2hIyw1CdQC4N8/Y9Zs6b2aBiAHjqAf3lfBUN4oYJi0isetOfQpyg==
   dependencies:
     http-proxy-agent "^5.0.0"
     https-proxy-agent "^5.0.0"
 
-"@theia/terminal@1.39.0":
-  version "1.39.0"
-  resolved "https://registry.yarnpkg.com/@theia/terminal/-/terminal-1.39.0.tgz#5ed6cebe70bfa25be2a447923b31d1118f1bc541"
-  integrity sha512-a33ziDuLx+hF/3GvICvGTMBTdwQr96iUsiqBBDBNwIXoCIvG5Q33Pds0xNyH34Ik8XXRLSSWgyTiGK2eM6qreQ==
+"@theia/terminal@1.45.0":
+  version "1.45.0"
+  resolved "https://registry.yarnpkg.com/@theia/terminal/-/terminal-1.45.0.tgz#374c9993dc1d6cb10f4c1319a7bcde307b58e4df"
+  integrity sha512-kZkhN0R9MPFDRJybQ8iHRShcpDyRX5mxn2AklFw4JDM4dtvQbA9Io8hnaOHDNHnvh5OLf7tOnT/yWAvBnZ7khg==
   dependencies:
-    "@theia/core" "1.39.0"
-    "@theia/editor" "1.39.0"
-    "@theia/filesystem" "1.39.0"
-    "@theia/process" "1.39.0"
-    "@theia/variable-resolver" "1.39.0"
-    "@theia/workspace" "1.39.0"
+    "@theia/core" "1.45.0"
+    "@theia/editor" "1.45.0"
+    "@theia/filesystem" "1.45.0"
+    "@theia/process" "1.45.0"
+    "@theia/variable-resolver" "1.45.0"
+    "@theia/workspace" "1.45.0"
     xterm "^4.16.0"
     xterm-addon-fit "^0.5.0"
     xterm-addon-search "^0.8.2"
 
-"@theia/userstorage@1.39.0":
-  version "1.39.0"
-  resolved "https://registry.yarnpkg.com/@theia/userstorage/-/userstorage-1.39.0.tgz#774d4a9f9f29ce4f092cd1e3493cd879cdb2f732"
-  integrity sha512-2zuXUQpakhjZY5VS5I1v4kO05TP6yK7tsgKSQWblddQIK9sO/IlfwdEbIjbrWpyPcFZuQzaCL+TCuWz1ryFfzQ==
+"@theia/userstorage@1.45.0":
+  version "1.45.0"
+  resolved "https://registry.yarnpkg.com/@theia/userstorage/-/userstorage-1.45.0.tgz#ac90522cc56913ce0a9e2c31f2a1623aff150f7c"
+  integrity sha512-a5C47mFR4OS/CUVdUEUwgTk412s/2BmQ8/zWpEcFsVlW2ZzUWFxEa+mko3Fd+QwH1v7Sj6cJafmUvESNMgFmqg==
   dependencies:
-    "@theia/core" "1.39.0"
-    "@theia/filesystem" "1.39.0"
+    "@theia/core" "1.45.0"
+    "@theia/filesystem" "1.45.0"
 
-"@theia/variable-resolver@1.39.0":
-  version "1.39.0"
-  resolved "https://registry.yarnpkg.com/@theia/variable-resolver/-/variable-resolver-1.39.0.tgz#89463838476ab912ad9e1c6ccb8ce33b35f149dd"
-  integrity sha512-7JUMayOJekDcQbVGs2K1XhmDb+zlGL1n1bSwVC1K9/MxPlrcmoevEvMz36qboP+J6ym/S3kNchrth9lo0uxO9A==
+"@theia/variable-resolver@1.45.0":
+  version "1.45.0"
+  resolved "https://registry.yarnpkg.com/@theia/variable-resolver/-/variable-resolver-1.45.0.tgz#ad663c7e0734799c310b6e7576308b890f17bc3c"
+  integrity sha512-FtHaWFvznOroX7hlGMcsrxnf+bt8td07xYQqzVmTRZf6HDJg0bPTjBXwxbtMbKr0wxSQVPKp2w8PYK7J3McH/Q==
   dependencies:
-    "@theia/core" "1.39.0"
+    "@theia/core" "1.45.0"
 
-"@theia/workspace@1.39.0":
-  version "1.39.0"
-  resolved "https://registry.yarnpkg.com/@theia/workspace/-/workspace-1.39.0.tgz#bb29c466141b5584f3ae078cf658d5547950a4c9"
-  integrity sha512-3/mFMvgdkKj8+DPaWUGD0vQlFFlx7k6WKp5nAtOXz2DZSAb/wXlqH+ex0MgPtJZyCccg+YdVeoWW19Gpp6YWOA==
+"@theia/workspace@1.45.0":
+  version "1.45.0"
+  resolved "https://registry.yarnpkg.com/@theia/workspace/-/workspace-1.45.0.tgz#c406b3239d3e3cca573a019f71e458b0362f609e"
+  integrity sha512-x1+t4hKt+2zH7UugD5MjnpRfFG6itK9hVNx0D33rd8WKOI+Q/VuuA6RM6qpmQ5jVPnqTVX2mXrMVC4ZGKHUyQQ==
   dependencies:
-    "@theia/core" "1.39.0"
-    "@theia/filesystem" "1.39.0"
-    "@theia/variable-resolver" "1.39.0"
+    "@theia/core" "1.45.0"
+    "@theia/filesystem" "1.45.0"
+    "@theia/variable-resolver" "1.45.0"
     jsonc-parser "^2.2.0"
     valid-filename "^2.0.1"
 
@@ -2431,11 +2418,6 @@
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.4.tgz#d9748f5742171b26218516cf1828b8eafaf8a9fa"
   integrity sha512-2JwWnHK9H+wUZNorf2Zr6ves96WHoWDJIftkcxPKsS7Djta6Zu519LarhRNljPXkpsZR2ZMwNCPeW7omW07BJw==
-
-"@types/events@*":
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/@types/events/-/events-3.0.2.tgz#c9b18152fdac34e924260532762255e34ef1d491"
-  integrity sha512-v4Mr60wJuF069iZZCdY5DKhfj0l6eXNJtbSM/oMDNdRLoBEUsktmKnswkz0X3OAic5W8Qy/YU6owKE4A66Y46A==
 
 "@types/express-serve-static-core@^4.17.33":
   version "4.17.39"
@@ -2661,12 +2643,7 @@
   resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.5.tgz#4751153abbf8d6199babb345a52e1eb4167d64af"
   integrity sha512-s/FPdYRmZR8SjLWGMCuax7r3qCWQw9QKHzXVukAuuIJkXkDRwp+Pu5LMIVFi0Fxbav35WURicYr8u1QsoybnQw==
 
-"@types/semver@^5.4.0":
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-5.5.0.tgz#146c2a29ee7d3bae4bf2fcb274636e264c813c45"
-  integrity sha512-41qEJgBH/TWgo5NFSvBCJ1qkoi3Q6ONSF2avrHq1LVEZfYpdHmj0y9SuTK+u9ZhG1sYQKBL1AWXKyLWP4RaUoQ==
-
-"@types/semver@^7.3.8", "@types/semver@^7.5.0":
+"@types/semver@^7.5.0":
   version "7.5.4"
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.5.4.tgz#0a41252ad431c473158b22f9bfb9a63df7541cff"
   integrity sha512-MMzuxN3GdFwskAnb6fz0orFvhfqi752yjaXylr0Rp4oDg5H0Zn1IuyRhDVvYOwAXoJirx2xuS16I3WjxnAIHiQ==
@@ -2745,18 +2722,17 @@
   resolved "https://registry.yarnpkg.com/@types/write-json-file/-/write-json-file-2.2.1.tgz#74155aaccbb0d532be21f9d66bebc4ea875a5a62"
   integrity sha512-JdO/UpPm9RrtQBNVcZdt3M7j3mHO/kXaea9LBGx3UgWJd1f9BkIWP7jObLBG6ZtRyqp7KzLFEsaPhWcidVittA==
 
-"@types/ws@^5.1.2":
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/@types/ws/-/ws-5.1.2.tgz#f02d3b1cd46db7686734f3ce83bdf46c49decd64"
-  integrity sha512-NkTXUKTYdXdnPE2aUUbGOXE1XfMK527SCvU/9bj86kyFF6kZ9ZnOQ3mK5jADn98Y2vEUD/7wKDgZa7Qst2wYOg==
-  dependencies:
-    "@types/events" "*"
-    "@types/node" "*"
-
 "@types/ws@^8.5.4":
   version "8.5.8"
   resolved "https://registry.yarnpkg.com/@types/ws/-/ws-8.5.8.tgz#13efec7bd439d0bdf2af93030804a94f163b1430"
   integrity sha512-flUksGIQCnJd6sZ1l5dqCEG/ksaoAg/eUwiLAGTJQcfgvZJKF++Ta4bJA6A5aPSJmsr+xlseHn4KLgVlNnvPTg==
+  dependencies:
+    "@types/node" "*"
+
+"@types/ws@^8.5.5":
+  version "8.5.10"
+  resolved "https://registry.yarnpkg.com/@types/ws/-/ws-8.5.10.tgz#4acfb517970853fa6574a3a6886791d04a396787"
+  integrity sha512-vmQSUcfalpIq0R9q7uTo2lXs6eGIpt9wtnLdMv9LVpIjCA/+ufZRozlVoVelIYixx1ugCBKDhn89vnsEGOCx9A==
   dependencies:
     "@types/node" "*"
 
@@ -3886,7 +3862,7 @@ caseless@~0.12.0:
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==
 
-chai@^4.2.0, chai@^4.3.10:
+chai@^4.3.10:
   version "4.3.10"
   resolved "https://registry.yarnpkg.com/chai/-/chai-4.3.10.tgz#d784cec635e3b7e2ffb66446a63b4e33bd390384"
   integrity sha512-0UXG04VuVbruMUYbJ6JctvH0YnC/4q3/AkT18q4NaITo91CUm0liMS9VqzT9vZhVQ/1eqPanMWjBM+Juhfb/9g==
@@ -3981,10 +3957,10 @@ chrome-trace-event@^1.0.2:
   resolved "https://registry.yarnpkg.com/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz#1015eced4741e15d06664a957dbbf50d041e26ac"
   integrity sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==
 
-chromium-bidi@0.4.7:
-  version "0.4.7"
-  resolved "https://registry.yarnpkg.com/chromium-bidi/-/chromium-bidi-0.4.7.tgz#4c022c2b0fb1d1c9b571fadf373042160e71d236"
-  integrity sha512-6+mJuFXwTMU6I3vYLs6IL8A1DyQTPjCfIL971X0aMPVGRbGnNfl6i6Cl0NMbxi2bRYLGESt9T2ZIMRM5PAEcIQ==
+chromium-bidi@0.4.4:
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/chromium-bidi/-/chromium-bidi-0.4.4.tgz#44f25d4fa5d2f3debc3fc3948d0657194cac4407"
+  integrity sha512-4BX5cSaponuvVT1+SbLYTOAgDoVtX/Khoc9UsbFJ/AsPVUeFAM3RiIDFI6XFhLYMi9WmVJqh1ZH+dRpNKkKwiQ==
   dependencies:
     mitt "3.0.0"
 
@@ -4377,10 +4353,10 @@ cors@~2.8.5:
     object-assign "^4"
     vary "^1"
 
-cosmiconfig@8.1.3:
-  version "8.1.3"
-  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-8.1.3.tgz#0e614a118fcc2d9e5afc2f87d53cd09931015689"
-  integrity sha512-/UkO2JKI18b5jVMJUp0lvKFMpa/Gye+ZgZjKD+DGEN9y7NRcf/nK1A0sp67ONmKtnDCNMS44E6jrk0Yc3bDuUw==
+cosmiconfig@8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-8.0.0.tgz#e9feae014eab580f858f8a0288f38997a7bebe97"
+  integrity sha512-da1EafcpH6b/TD8vDRaWV7xFINlHlF6zKsGwS1TsuVJTZRkquaS5HTMq7uq6h31619QjbsYl21gVDOm32KM1vQ==
   dependencies:
     import-fresh "^3.2.1"
     js-yaml "^4.1.0"
@@ -4705,10 +4681,10 @@ detect-node@^2.0.4:
   resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.1.0.tgz#c9c70775a49c3d03bc2c06d9a73be550f978f8b1"
   integrity sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==
 
-devtools-protocol@0.0.1107588:
-  version "0.0.1107588"
-  resolved "https://registry.yarnpkg.com/devtools-protocol/-/devtools-protocol-0.0.1107588.tgz#f8cac707840b97cc30b029359341bcbbb0ad8ffa"
-  integrity sha512-yIR+pG9x65Xko7bErCUSQaDLrO/P1p3JUzEk7JCU4DowPcGHkTGUGQapcfcLc4qj0UaALwZ+cr0riFgiqpixcg==
+devtools-protocol@0.0.1094867:
+  version "0.0.1094867"
+  resolved "https://registry.yarnpkg.com/devtools-protocol/-/devtools-protocol-0.0.1094867.tgz#2ab93908e9376bd85d4e0604aa2651258f13e374"
+  integrity sha512-pmMDBKiRVjh0uKK6CT1WqZmM3hBVSgD+N2MrgyV1uNizAZMw4tx6i/RTc+/uCsKSCmg0xXx7arCP/OFcIwTsiQ==
 
 diff-sequences@^29.6.3:
   version "29.6.3"
@@ -7842,26 +7818,26 @@ ms@2.1.3, ms@^2.0.0, ms@^2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
-msgpackr-extract@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/msgpackr-extract/-/msgpackr-extract-3.0.2.tgz#e05ec1bb4453ddf020551bcd5daaf0092a2c279d"
-  integrity sha512-SdzXp4kD/Qf8agZ9+iTu6eql0m3kWm1A2y1hkpTeVNENutaB0BwHlSvAIaMxwntmRUAUjon2V4L8Z/njd0Ct8A==
+msgpackr-extract@^2.0.2:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/msgpackr-extract/-/msgpackr-extract-2.2.0.tgz#4bb749b58d9764cfdc0d91c7977a007b08e8f262"
+  integrity sha512-0YcvWSv7ZOGl9Od6Y5iJ3XnPww8O7WLcpYMDwX+PAA/uXLDtyw94PJv9GLQV/nnp3cWlDhMoyKZIQLrx33sWog==
   dependencies:
-    node-gyp-build-optional-packages "5.0.7"
+    node-gyp-build-optional-packages "5.0.3"
   optionalDependencies:
-    "@msgpackr-extract/msgpackr-extract-darwin-arm64" "3.0.2"
-    "@msgpackr-extract/msgpackr-extract-darwin-x64" "3.0.2"
-    "@msgpackr-extract/msgpackr-extract-linux-arm" "3.0.2"
-    "@msgpackr-extract/msgpackr-extract-linux-arm64" "3.0.2"
-    "@msgpackr-extract/msgpackr-extract-linux-x64" "3.0.2"
-    "@msgpackr-extract/msgpackr-extract-win32-x64" "3.0.2"
+    "@msgpackr-extract/msgpackr-extract-darwin-arm64" "2.2.0"
+    "@msgpackr-extract/msgpackr-extract-darwin-x64" "2.2.0"
+    "@msgpackr-extract/msgpackr-extract-linux-arm" "2.2.0"
+    "@msgpackr-extract/msgpackr-extract-linux-arm64" "2.2.0"
+    "@msgpackr-extract/msgpackr-extract-linux-x64" "2.2.0"
+    "@msgpackr-extract/msgpackr-extract-win32-x64" "2.2.0"
 
-msgpackr@^1.6.1:
-  version "1.9.9"
-  resolved "https://registry.yarnpkg.com/msgpackr/-/msgpackr-1.9.9.tgz#ec71e37beb8729280847f683cb0a340eb35ce70f"
-  integrity sha512-sbn6mioS2w0lq1O6PpGtsv6Gy8roWM+o3o4Sqjd6DudrL/nOugY+KyJUimoWzHnf9OkO0T6broHFnYE/R05t9A==
+msgpackr@1.6.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/msgpackr/-/msgpackr-1.6.1.tgz#4f3c94d6a5b819b838ffc736eddaf60eba436d20"
+  integrity sha512-Je+xBEfdjtvA4bKaOv8iRhjC8qX2oJwpYH4f7JrG4uMVJVmnmkAT4pjKdbztKprGj3iwjcxPzb5umVZ02Qq3tA==
   optionalDependencies:
-    msgpackr-extract "^3.0.2"
+    msgpackr-extract "^2.0.2"
 
 multer@1.4.4-lts.1:
   version "1.4.4-lts.1"
@@ -8033,10 +8009,10 @@ node-fetch@^2.6.0, node-fetch@^2.6.11, node-fetch@^2.6.7:
   dependencies:
     whatwg-url "^5.0.0"
 
-node-gyp-build-optional-packages@5.0.7:
-  version "5.0.7"
-  resolved "https://registry.yarnpkg.com/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.0.7.tgz#5d2632bbde0ab2f6e22f1bbac2199b07244ae0b3"
-  integrity sha512-YlCCc6Wffkx0kHkmam79GKvDQ6x+QZkMjFGrIMxgFNILFvGSbCp2fCBC55pGTT9gVaz8Na5CLmxt/urtzRv36w==
+node-gyp-build-optional-packages@5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.0.3.tgz#92a89d400352c44ad3975010368072b41ad66c17"
+  integrity sha512-k75jcVzk5wnnc/FMxsf4udAoTEUv2jY3ycfdSd3yWu6Cnd1oee6/CfZJApyscA4FJOmdoixWwiwOyf16RzD5JA==
 
 node-gyp-build@^4.2.1, node-gyp-build@^4.3.0:
   version "4.6.1"
@@ -9082,24 +9058,24 @@ punycode@^2.1.0, punycode@^2.1.1:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.1.tgz#027422e2faec0b25e1549c3e1bd8309b9133b6e5"
   integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
 
-puppeteer-core@19.11.1, puppeteer-core@^19.7.2:
-  version "19.11.1"
-  resolved "https://registry.yarnpkg.com/puppeteer-core/-/puppeteer-core-19.11.1.tgz#4c63d7a0a6cd268ff054ebcac315b646eee32667"
-  integrity sha512-qcuC2Uf0Fwdj9wNtaTZ2OvYRraXpAK+puwwVW8ofOhOgLPZyz1c68tsorfIZyCUOpyBisjr+xByu7BMbEYMepA==
+puppeteer-core@19.7.2:
+  version "19.7.2"
+  resolved "https://registry.yarnpkg.com/puppeteer-core/-/puppeteer-core-19.7.2.tgz#deee9ef915829b6a1d1a3a008625c29eeb251161"
+  integrity sha512-PvI+fXqgP0uGJxkyZcX51bnzjFA73MODZOAv0fSD35yR7tvbqwtMV3/Y+hxQ0AMMwzxkEebP6c7po/muqxJvmQ==
   dependencies:
-    "@puppeteer/browsers" "0.5.0"
-    chromium-bidi "0.4.7"
+    chromium-bidi "0.4.4"
     cross-fetch "3.1.5"
     debug "4.3.4"
-    devtools-protocol "0.0.1107588"
+    devtools-protocol "0.0.1094867"
     extract-zip "2.0.1"
     https-proxy-agent "5.0.1"
     proxy-from-env "1.1.0"
+    rimraf "3.0.2"
     tar-fs "2.1.1"
     unbzip2-stream "1.4.3"
-    ws "8.13.0"
+    ws "8.11.0"
 
-puppeteer-to-istanbul@^1.4.0:
+puppeteer-to-istanbul@1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/puppeteer-to-istanbul/-/puppeteer-to-istanbul-1.4.0.tgz#451dced6f42652448f55cf0bc780b35512c8d1b0"
   integrity sha512-dzW8u/PMqMZppvoXCFod8IkCTI2JL0yP2YUBbaALnX+iJJ6gqjk77fIoK9MqnMqRZAcoa81GLFfZExakWg/Q4Q==
@@ -9109,17 +9085,16 @@ puppeteer-to-istanbul@^1.4.0:
     v8-to-istanbul "^1.2.1"
     yargs "^15.3.1"
 
-puppeteer@^19.7.2:
-  version "19.11.1"
-  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-19.11.1.tgz#bb75d518e87b0b4f6ef9bad1ea7e9d1cdcd18a5d"
-  integrity sha512-39olGaX2djYUdhaQQHDZ0T0GwEp+5f9UB9HmEP0qHfdQHIq0xGQZuAZ5TLnJIc/88SrPLpEflPC+xUqOTv3c5g==
+puppeteer@19.7.2:
+  version "19.7.2"
+  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-19.7.2.tgz#1b3ce99a093cc2f8f84dfb06f066d0757ea79d4b"
+  integrity sha512-4Lm7Qpe/LU95Svirei/jDLDvR5oMrl9BPGd7HMY5+Q28n+BhvKuW97gKkR+1LlI86bO8J3g8rG/Ll5kv9J1nlQ==
   dependencies:
-    "@puppeteer/browsers" "0.5.0"
-    cosmiconfig "8.1.3"
+    cosmiconfig "8.0.0"
     https-proxy-agent "5.0.1"
     progress "2.0.3"
     proxy-from-env "1.1.0"
-    puppeteer-core "19.11.1"
+    puppeteer-core "19.7.2"
 
 qs@6.11.0:
   version "6.11.0"
@@ -9532,7 +9507,7 @@ rimraf@2, rimraf@^2.6.2:
   dependencies:
     glob "^7.1.3"
 
-rimraf@^3.0.0, rimraf@^3.0.2:
+rimraf@3.0.2, rimraf@^3.0.0, rimraf@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
@@ -10152,6 +10127,11 @@ stack-trace@0.0.x:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/stack-trace/-/stack-trace-0.0.10.tgz#547c70b347e8d32b4e108ea1a2a159e5fdde19c0"
   integrity sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==
+
+stat-mode@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/stat-mode/-/stat-mode-1.0.0.tgz#68b55cb61ea639ff57136f36b216a291800d1465"
+  integrity sha512-jH9EhtKIjuXZ2cWxmXS8ZP80XyC3iasQxMDV8jzhNJpfDb7VbQLVW4Wvsxz9QZvzV+G4YoSfBUVKDOyxLzi/sg==
 
 statuses@2.0.1:
   version "2.0.1"
@@ -11083,10 +11063,10 @@ vscode-oniguruma@1.6.1:
   resolved "https://registry.yarnpkg.com/vscode-oniguruma/-/vscode-oniguruma-1.6.1.tgz#2bf4dfcfe3dd2e56eb549a3068c8ee39e6c30ce5"
   integrity sha512-vc4WhSIaVpgJ0jJIejjYxPvURJavX6QG41vu0mGhqywMkQqulezEqEQ3cO3gc8GvcOpX6ycmKGqRoROEMBNXTQ==
 
-vscode-textmate@^7.0.3:
-  version "7.0.4"
-  resolved "https://registry.yarnpkg.com/vscode-textmate/-/vscode-textmate-7.0.4.tgz#a30df59ce573e998e4e2ffbca5ab82d57bc3126f"
-  integrity sha512-9hJp0xL7HW1Q5OgGe03NACo7yiCTMEk3WU/rtKXUbncLtdg6rVVNJnHwD88UhbIYU2KoxY0Dih0x+kIsmUKn2A==
+vscode-textmate@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/vscode-textmate/-/vscode-textmate-9.0.0.tgz#313c6c8792b0507aef35aeb81b6b370b37c44d6c"
+  integrity sha512-Cl65diFGxz7gpwbav10HqiY/eVYTO1sjQpmRmV991Bj7wAoOAjGQ97PpQcXorDE2Uc4hnGWLY17xme+5t6MlSg==
 
 vscode-uri@^2.1.1:
   version "2.1.2"
@@ -11379,25 +11359,20 @@ write-pkg@4.0.0:
     type-fest "^0.4.1"
     write-json-file "^3.2.0"
 
-ws@8.13.0:
-  version "8.13.0"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.13.0.tgz#9a9fb92f93cf41512a0735c8f4dd09b8a1211cd0"
-  integrity sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==
-
-ws@^7.1.2:
-  version "7.5.9"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.9.tgz#54fa7db29f4c7cec68b1ddd3a89de099942bb591"
-  integrity sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==
+ws@8.11.0, ws@~8.11.0:
+  version "8.11.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.11.0.tgz#6a0d36b8edfd9f96d8b25683db2f8d7de6e8e143"
+  integrity sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==
 
 ws@^8.12.1:
   version "8.14.2"
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.14.2.tgz#6c249a806eb2db7a20d26d51e7709eab7b2e6c7f"
   integrity sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==
 
-ws@~8.11.0:
-  version "8.11.0"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.11.0.tgz#6a0d36b8edfd9f96d8b25683db2f8d7de6e8e143"
-  integrity sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==
+ws@^8.14.1:
+  version "8.16.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.16.0.tgz#d1cd774f36fbc07165066a60e40323eab6446fd4"
+  integrity sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==
 
 xdg-basedir@^4.0.0:
   version "4.0.0"
@@ -11522,19 +11497,6 @@ yargs@16.2.0, yargs@^16.2.0:
     string-width "^4.2.0"
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
-
-yargs@17.7.1:
-  version "17.7.1"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.1.tgz#34a77645201d1a8fc5213ace787c220eabbd0967"
-  integrity sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==
-  dependencies:
-    cliui "^8.0.1"
-    escalade "^3.1.1"
-    get-caller-file "^2.0.5"
-    require-directory "^2.1.1"
-    string-width "^4.2.3"
-    y18n "^5.0.5"
-    yargs-parser "^21.1.1"
 
 yargs@^15.0.2, yargs@^15.3.1:
   version "15.4.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -977,12 +977,12 @@
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
   integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==
 
-"@eclipse-glsp-examples/workflow-glsp@2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp-examples/workflow-glsp/-/workflow-glsp-2.1.0.tgz#4ff8660dce094a2ad31e7034eae3a220bbfb80cd"
-  integrity sha512-uHn8dRutEO00F7KsZZEhRBnu4J6gRkFB4yTeVimtBik5FXld+z+zY7AfSfrfz+AJ9Fu+aEIZyyzHASmlWLvXOA==
+"@eclipse-glsp-examples/workflow-glsp@next":
+  version "2.3.0-next.309"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp-examples/workflow-glsp/-/workflow-glsp-2.3.0-next.309.tgz#d30a23276b5759f6601a3f64cb34392ae2ef468f"
+  integrity sha512-k7Ds2IEnYQLxHk59L3q3/MYpuYXm93KzIQymvEKrSCI5blyT8fnjZR9a4buIeJAa5P87eAM5yGnq0aQuWUX/oA==
   dependencies:
-    "@eclipse-glsp/client" "2.1.0"
+    "@eclipse-glsp/client" "2.3.0-next.309+b90a740"
     balloon-css "^0.5.0"
 
 "@eclipse-glsp-examples/workflow-server-bundled@next":
@@ -990,13 +990,13 @@
   resolved "https://registry.yarnpkg.com/@eclipse-glsp-examples/workflow-server-bundled/-/workflow-server-bundled-2.1.0-next.71.tgz#7020bf62edb186a7108a3e2bab992efcfeedaab7"
   integrity sha512-dKwd+8pz4kULnWHoSGhNKS90iP5jtdfBzl85vU60Zz9401DMADXXJXZxtFPRiwJydPNdPdWKzb4WRhowjXZlmA==
 
-"@eclipse-glsp-examples/workflow-server@2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp-examples/workflow-server/-/workflow-server-2.1.0.tgz#63af096a4138677c0f50359d44c8eeed3cfc7aed"
-  integrity sha512-VBcVJY8mmI6nsLvND2x0LX/+Osi6JpQ+eGok7tbbcr3QZfbG83EcUiKCt2xlzkBaaoTlo6UQyelqN6W8MQe+DQ==
+"@eclipse-glsp-examples/workflow-server@next":
+  version "2.2.0-next.82"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp-examples/workflow-server/-/workflow-server-2.2.0-next.82.tgz#ac7ad5a63a63175ae8a66cc70fd2d54e7d6b598a"
+  integrity sha512-yWcRm5GmieJbs9p6crjvRMlfaDEPLm1WE97FZKwwcTgN9SeYzqaYPHaOZR+fsz7480MtGFIpJO2isqWZOLUiKw==
   dependencies:
-    "@eclipse-glsp/layout-elk" "2.1.0"
-    "@eclipse-glsp/server" "2.1.0"
+    "@eclipse-glsp/layout-elk" "2.2.0-next.82+10dd95b"
+    "@eclipse-glsp/server" "2.2.0-next.82+10dd95b"
     inversify "^6.0.1"
 
 "@eclipse-glsp/cli@~2.0.0":
@@ -1011,12 +1011,12 @@
     semver "^7.5.1"
     shelljs "^0.8.5"
 
-"@eclipse-glsp/client@2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp/client/-/client-2.1.0.tgz#324c48e243cb24d454c9c4a38dcd7effea92b729"
-  integrity sha512-OxQhgcz1VJnmj4IYMSz7Xp4bk50yX/nvrcdVyBvnWJ0S2FF9rJZcdMykooMg19N0nfnG+cjzVa4lbd5Mf975XQ==
+"@eclipse-glsp/client@2.3.0-next.309+b90a740", "@eclipse-glsp/client@next":
+  version "2.3.0-next.309"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp/client/-/client-2.3.0-next.309.tgz#c5c8a13dfc85f6c6ed1426c410091862d348a2f5"
+  integrity sha512-CcZLBiGnQQztxtR1kE802M6D5MYM6o4zT52RV4qzd1rywzjYZS81lprm3+jYmPK66a2fLiSlDXCix3X2zZPCbg==
   dependencies:
-    "@eclipse-glsp/sprotty" "2.1.0"
+    "@eclipse-glsp/sprotty" "2.3.0-next.309+b90a740"
     autocompleter "^9.1.0"
     file-saver "^2.0.5"
     lodash "4.17.21"
@@ -1076,19 +1076,19 @@
   resolved "https://registry.yarnpkg.com/@eclipse-glsp/eslint-config/-/eslint-config-2.0.0.tgz#d2070c5e10b0e3fcc3c5ab3a5fcc1dcf0596980e"
   integrity sha512-cne25IFXtX7Ab5oN98IkUulBVrZ7x2mnutyDilTkC132f4vZuPE1aWBY4HOyUbfODVLN2xpQckJQF9X1qdnYNA==
 
-"@eclipse-glsp/graph@2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp/graph/-/graph-2.1.0.tgz#f6d82310ed52ca9eab1c6640857fcc49fbcf2515"
-  integrity sha512-TGreAQ4cSCln0BIBiQ89276RRCBW70Y5ifXJ+qpfWYCbnWnTXwepRdy6Q/OXY5zwjcH7doXSQnmDv5hODVI/ww==
+"@eclipse-glsp/graph@2.2.0-next.82+10dd95b":
+  version "2.2.0-next.82"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp/graph/-/graph-2.2.0-next.82.tgz#553fd53af0be91df0f932af2715a7501580bff72"
+  integrity sha512-TJdxxVQbXM5sV2w+5G3I+tPVWICRNalcK4TDJI37y4gLd0N39gPDwq2GKzOCWpvR/h5PYA6rl1+N09qHWk911A==
   dependencies:
-    "@eclipse-glsp/protocol" "2.1.0"
+    "@eclipse-glsp/protocol" next
 
-"@eclipse-glsp/layout-elk@2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp/layout-elk/-/layout-elk-2.1.0.tgz#0a228e6b67673bda69c1c498e9bd8c06d0e11227"
-  integrity sha512-FUE78Du62FEBU9HbF7gcJMlyMFT4C1ZYEPlY/4NOdl6HlI9IbXdeS2z/sv/xIBUCuSDk3YoRQhGe2wLWynRWmg==
+"@eclipse-glsp/layout-elk@2.2.0-next.82+10dd95b":
+  version "2.2.0-next.82"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp/layout-elk/-/layout-elk-2.2.0-next.82.tgz#4ad4d29ac8d75c77a2ba677accc5b907f828b15e"
+  integrity sha512-01YytlXmTEXIYHJFhYIJS6ZAbNmkzckNCbe9oFj1dvcq3S/WZOLeWxRzSeJM5Dl95hjqFV7oluXgXC61XBMPwQ==
   dependencies:
-    "@eclipse-glsp/server" "2.1.0"
+    "@eclipse-glsp/server" "2.2.0-next.82+10dd95b"
     elkjs "^0.7.1"
 
 "@eclipse-glsp/mocha-config@~2.0.0":
@@ -1108,34 +1108,34 @@
   dependencies:
     prettier-plugin-packagejson "~2.4.6"
 
-"@eclipse-glsp/protocol@2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp/protocol/-/protocol-2.1.0.tgz#e76a65a4815c969bfb86a1ab202ad24384a317cc"
-  integrity sha512-CUcVbsjiddDWEuhWKDLgfqslmau2QT6QTF9LyA4/y6Eomv5s8nTexeBMI6hCWL4sHgMfQ4t2zI9zV2a5gIow4A==
+"@eclipse-glsp/protocol@2.3.0-next.309+b90a740", "@eclipse-glsp/protocol@next":
+  version "2.3.0-next.309"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp/protocol/-/protocol-2.3.0-next.309.tgz#e30496338846462be6ef8c91c0f42b0e4bd0875a"
+  integrity sha512-KHF90oL4MTo19HEFlvXCpe9xqk92jU4ezbgNALGa27OZ5NOEJgY02aJrs2od4i6YOF6swRO3pPoGts0WH9dDEQ==
   dependencies:
     sprotty-protocol "0.15.0-next.044bba2.13"
     uuid "7.0.3"
     vscode-jsonrpc "^8.0.2"
 
-"@eclipse-glsp/server@2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp/server/-/server-2.1.0.tgz#6c281904f974de8ac9893994f2d5c3a144dbf557"
-  integrity sha512-0xPkDLt54hMjNyX33KJFP18O1nUV8U318jYZy6CZfJClnacWrKk8SQKBEUlzhpDFMUrZBvArKmwRylq0pnHpfw==
+"@eclipse-glsp/server@2.2.0-next.82+10dd95b":
+  version "2.2.0-next.82"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp/server/-/server-2.2.0-next.82.tgz#cfa198fd86ade406633ef8582f4786a06513c415"
+  integrity sha512-Um+usqv5Cz9ctEC/rFk8cLzXJj0MuuyHtCYfeAlOkuiVm4HalrlMddRVjH3yUnDGH1vsl/ku+iKEzFdSLwh0/g==
   dependencies:
-    "@eclipse-glsp/graph" "2.1.0"
-    "@eclipse-glsp/protocol" "2.1.0"
+    "@eclipse-glsp/graph" "2.2.0-next.82+10dd95b"
+    "@eclipse-glsp/protocol" next
     "@types/uuid" "8.3.1"
     commander "^8.3.0"
     fast-json-patch "^3.1.0"
     winston "^3.3.3"
     ws "^8.12.1"
 
-"@eclipse-glsp/sprotty@2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp/sprotty/-/sprotty-2.1.0.tgz#4adf93dd501dc65426f7beac145ac007fcb37aa9"
-  integrity sha512-STBH3Af9sTD102mfgr0kplMSkvkkWIOMGLjr7Hl+b5yx8niMrFmy6HGIBVpyw9mb5DW+6eKN+3QjyslTetL8TA==
+"@eclipse-glsp/sprotty@2.3.0-next.309+b90a740":
+  version "2.3.0-next.309"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp/sprotty/-/sprotty-2.3.0-next.309.tgz#e987d28caeb5c3cf26b0986fbd7b671066f902e1"
+  integrity sha512-o97h9GcNEvgTNfwh6pw6AnGQF2HenD6UHzuuN4Pj868c+PZmAEk/hY96QBEOnXCiUn1aI4F2mXHq+3OBiWoIQg==
   dependencies:
-    "@eclipse-glsp/protocol" "2.1.0"
+    "@eclipse-glsp/protocol" "2.3.0-next.309+b90a740"
     autocompleter "^9.1.0"
     snabbdom "^3.5.1"
     sprotty "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1939,18 +1939,18 @@
   dependencies:
     defer-to-connect "^2.0.0"
 
-"@theia/application-manager@1.45.0":
-  version "1.45.0"
-  resolved "https://registry.yarnpkg.com/@theia/application-manager/-/application-manager-1.45.0.tgz#b51c4598a349e475d20c03a1477a8277ae3e084d"
-  integrity sha512-m5ikhVCTtWVB6ZznGWCpQDHE/lWsCRhEaYcneCABcny7QBDz64YOBQWZ1MATwAtedeQ6uPT0rL6bdtrYC6N+vA==
+"@theia/application-manager@1.45.1":
+  version "1.45.1"
+  resolved "https://registry.yarnpkg.com/@theia/application-manager/-/application-manager-1.45.1.tgz#0d4fc03207cc618fbe477964ddd5aa2b11c9d61e"
+  integrity sha512-3tflWRFvRGnJMS1n9+jIEbmKLITNZ11y+ArEt9k++s90Sb7IgfEyRYwwARS5k9yLwJM0cZ2BcKjB14tZSd8u/g==
   dependencies:
     "@babel/core" "^7.10.0"
     "@babel/plugin-transform-classes" "^7.10.0"
     "@babel/plugin-transform-runtime" "^7.10.0"
     "@babel/preset-env" "^7.10.0"
-    "@theia/application-package" "1.45.0"
-    "@theia/ffmpeg" "1.45.0"
-    "@theia/native-webpack-plugin" "1.45.0"
+    "@theia/application-package" "1.45.1"
+    "@theia/ffmpeg" "1.45.1"
+    "@theia/native-webpack-plugin" "1.45.1"
     "@types/fs-extra" "^4.0.2"
     "@types/semver" "^7.5.0"
     babel-loader "^8.2.2"
@@ -1979,12 +1979,12 @@
     worker-loader "^3.0.8"
     yargs "^15.3.1"
 
-"@theia/application-package@1.45.0":
-  version "1.45.0"
-  resolved "https://registry.yarnpkg.com/@theia/application-package/-/application-package-1.45.0.tgz#47c6cd35e0143afa263d51db5c0b7114872e44b0"
-  integrity sha512-14unjOa0yKjJ70fWxuz27shdDbdAqDcH09TmM2WHByIgVGu3CfhJaH77FPevf0DBu1A+Z2280ulCKD89+rb9TA==
+"@theia/application-package@1.45.1":
+  version "1.45.1"
+  resolved "https://registry.yarnpkg.com/@theia/application-package/-/application-package-1.45.1.tgz#37f83332e9ffbc1092b447b8f9a927e07649179d"
+  integrity sha512-GPAuyBlEAUiwaGVPiDIJexD03zE2COD3CLM7AkW2svDQny8V23ktjh6D4xnyHIWdWoMmkYOCFJK1CMkwXBDbcw==
   dependencies:
-    "@theia/request" "1.45.0"
+    "@theia/request" "1.45.1"
     "@types/fs-extra" "^4.0.2"
     "@types/semver" "^7.5.0"
     "@types/write-json-file" "^2.2.1"
@@ -1996,17 +1996,17 @@
     semver "^7.5.4"
     write-json-file "^2.2.0"
 
-"@theia/cli@1.45.0":
-  version "1.45.0"
-  resolved "https://registry.yarnpkg.com/@theia/cli/-/cli-1.45.0.tgz#4563703371f1eb2cde960284481d7360181e58c5"
-  integrity sha512-k5IS3bhks3WPZ9w2qPojIhNfE5wgXs6AtW/XOwResYeLXWxRCpsiooX0Rj/IcJKN7hJZiu7dk0R5QhG7shsiIw==
+"@theia/cli@1.45.1":
+  version "1.45.1"
+  resolved "https://registry.yarnpkg.com/@theia/cli/-/cli-1.45.1.tgz#98de62a1900df44df399094e53e9cd2ad5e92dc1"
+  integrity sha512-RgPXUGCReJlShzJf42lZZqf3wfi/ocCKNtn5PrXzd3d7F+PKSFOLKtR3RAo61yq/62OHSgLYLVndZHxUJWFztA==
   dependencies:
-    "@theia/application-manager" "1.45.0"
-    "@theia/application-package" "1.45.0"
-    "@theia/ffmpeg" "1.45.0"
-    "@theia/localization-manager" "1.45.0"
-    "@theia/ovsx-client" "1.45.0"
-    "@theia/request" "1.45.0"
+    "@theia/application-manager" "1.45.1"
+    "@theia/application-package" "1.45.1"
+    "@theia/ffmpeg" "1.45.1"
+    "@theia/localization-manager" "1.45.1"
+    "@theia/ovsx-client" "1.45.1"
+    "@theia/request" "1.45.1"
     "@types/chai" "^4.2.7"
     "@types/mocha" "^10.0.0"
     "@types/node-fetch" "^2.5.7"
@@ -2024,10 +2024,10 @@
     temp "^0.9.1"
     yargs "^15.3.1"
 
-"@theia/core@1.45.0":
-  version "1.45.0"
-  resolved "https://registry.yarnpkg.com/@theia/core/-/core-1.45.0.tgz#f0a2c36ccb89cf38d4717ef1a58b4c83ccefe41d"
-  integrity sha512-7kTkDKxSX+IO0j/gWVphWZTXLv1pHSk4R5NlSIfDJapnLWU8F3l0uJSmwqw5T1V+WxMCJYnVai+DCm7h3kQoyw==
+"@theia/core@1.45.1":
+  version "1.45.1"
+  resolved "https://registry.yarnpkg.com/@theia/core/-/core-1.45.1.tgz#5ad8c52950f393a3b428ecd78e95858a6c8d8cfa"
+  integrity sha512-FWyYtqDAgfx4hMY3kFrY5KiFQuT79NmtqhzswlGgn8AjMg3QBnssIRfTPoqlo2ltl8XNBF3O7GziAVTTTTImFg==
   dependencies:
     "@babel/runtime" "^7.10.0"
     "@phosphor/algorithm" "1"
@@ -2040,8 +2040,8 @@
     "@phosphor/signaling" "1"
     "@phosphor/virtualdom" "1"
     "@phosphor/widgets" "1"
-    "@theia/application-package" "1.45.0"
-    "@theia/request" "1.45.0"
+    "@theia/application-package" "1.45.1"
+    "@theia/request" "1.45.1"
     "@types/body-parser" "^1.16.4"
     "@types/cookie" "^0.3.3"
     "@types/dompurify" "^2.2.2"
@@ -2098,28 +2098,28 @@
     ws "^8.14.1"
     yargs "^15.3.1"
 
-"@theia/editor@1.45.0":
-  version "1.45.0"
-  resolved "https://registry.yarnpkg.com/@theia/editor/-/editor-1.45.0.tgz#4f43c25705ef71bef33c7875bafe86402446cc64"
-  integrity sha512-ifh+V1xng3PbsI05PkZDBBqtiNhiAxag1DlNYDaI7BqfEJ/OoJVJrKzrDr7JXIhLaK/UQNb+tk3OPdqLrJFRiA==
+"@theia/editor@1.45.1":
+  version "1.45.1"
+  resolved "https://registry.yarnpkg.com/@theia/editor/-/editor-1.45.1.tgz#7b86cc55c20a1d2bc1b33bda7829a639c09f2667"
+  integrity sha512-/JAM2gqiVY6oV6f7o0cZa2cfsktUf2wb3yF89Fm5W7XKDI1QjQbCzOfi8j34vir1/uxNILg8U+E9ixnPI3ClgA==
   dependencies:
-    "@theia/core" "1.45.0"
-    "@theia/variable-resolver" "1.45.0"
+    "@theia/core" "1.45.1"
+    "@theia/variable-resolver" "1.45.1"
 
-"@theia/ffmpeg@1.45.0":
-  version "1.45.0"
-  resolved "https://registry.yarnpkg.com/@theia/ffmpeg/-/ffmpeg-1.45.0.tgz#34ed4f08d5acb596ad0ce973baa920b3005cacbe"
-  integrity sha512-qDi91J5Md/NiFgm4xd+JMZ6W4yLWQH0rmgZOUrBpdQVZ0AWiS1DZhXQtD0DQNK45Om4LZTDjfXNEDezK9XFbGA==
+"@theia/ffmpeg@1.45.1":
+  version "1.45.1"
+  resolved "https://registry.yarnpkg.com/@theia/ffmpeg/-/ffmpeg-1.45.1.tgz#565c17d5c5518de7dd8bfba9fe6696b8396e51bf"
+  integrity sha512-y5b7Bl0rYqPj0jHgRq2Z+B3fG83Sq6mymfKL2BkoBEBMOVEVQb0y5b5cWv0LNox5exf+tGpfA+PDILXLWAGYWg==
   dependencies:
     "@electron/get" "^2.0.0"
     unzipper "^0.9.11"
 
-"@theia/filesystem@1.45.0":
-  version "1.45.0"
-  resolved "https://registry.yarnpkg.com/@theia/filesystem/-/filesystem-1.45.0.tgz#b3637c4ce6b9a11b0982a4d21aecb149102f4409"
-  integrity sha512-rwc+epRpF4G7cmpaD1pLNH0UBPikz4p+EydV3YWC70t8izXzvv6DPqQ4JtrZzqUuOmH25pomSxYkBj/KRgyW0g==
+"@theia/filesystem@1.45.1":
+  version "1.45.1"
+  resolved "https://registry.yarnpkg.com/@theia/filesystem/-/filesystem-1.45.1.tgz#fa1859576d2f0369e5065353ac445389b952dd7c"
+  integrity sha512-p/SRWJ8jxnIG/nosYKQLaA0ohKckb/NdLRxVCbjgZO6UIh9BjzYVpQvAPD+E7fWN4r1X12fej0qNMXtutF3DmQ==
   dependencies:
-    "@theia/core" "1.45.0"
+    "@theia/core" "1.45.1"
     "@types/body-parser" "^1.17.0"
     "@types/multer" "^1.4.7"
     "@types/rimraf" "^2.0.2"
@@ -2137,10 +2137,10 @@
     uuid "^8.0.0"
     vscode-languageserver-textdocument "^1.0.1"
 
-"@theia/localization-manager@1.45.0":
-  version "1.45.0"
-  resolved "https://registry.yarnpkg.com/@theia/localization-manager/-/localization-manager-1.45.0.tgz#a9ba5fb5b8a3936dfb2b5cc623c8c4976acbbeff"
-  integrity sha512-JvOkOmduD8mUCmiwe2ezlIUuJXMwDWrYxQ5UvIOINmoWDxy6chpFy1k2ZbjYYO3k3rWgR9YsdWPbf9NmzXuB7w==
+"@theia/localization-manager@1.45.1":
+  version "1.45.1"
+  resolved "https://registry.yarnpkg.com/@theia/localization-manager/-/localization-manager-1.45.1.tgz#bd9932faf5d6a0d92013094c4d2784d4401a98cf"
+  integrity sha512-sgpfYGrOkNK+9vafdpmCZKacOzgmo01H+qr2lXoyRkLxBcxisOzpYkIukU1mDzmGedUXKz4a46Qk16uSKHgYjQ==
   dependencies:
     "@types/bent" "^7.0.1"
     "@types/fs-extra" "^4.0.2"
@@ -2151,21 +2151,21 @@
     glob "^7.2.0"
     typescript "~4.5.5"
 
-"@theia/markers@1.45.0":
-  version "1.45.0"
-  resolved "https://registry.yarnpkg.com/@theia/markers/-/markers-1.45.0.tgz#e54b474b8cef5b061b17282202121663474cc09c"
-  integrity sha512-pxMu7eu0gzcrY5ec7r9kmMZlKzqy9y2lM7/T9yBGs4EO1iCK1mrBEaf5KJ7MnH44mDfvf7zSME8VfCrOg8JVrw==
+"@theia/markers@1.45.1":
+  version "1.45.1"
+  resolved "https://registry.yarnpkg.com/@theia/markers/-/markers-1.45.1.tgz#a41f07fcc4258239b46eb6deb9eb76650253073e"
+  integrity sha512-s8qwwWR6vJQlYgrIJIUZx/uamH0D8spYDt4cCEU9enkdNkjI82e+gd8B1y0EmwJkmwAJ+ftg8ANfXQraVRnARA==
   dependencies:
-    "@theia/core" "1.45.0"
-    "@theia/filesystem" "1.45.0"
-    "@theia/workspace" "1.45.0"
+    "@theia/core" "1.45.1"
+    "@theia/filesystem" "1.45.1"
+    "@theia/workspace" "1.45.1"
 
-"@theia/messages@1.45.0":
-  version "1.45.0"
-  resolved "https://registry.yarnpkg.com/@theia/messages/-/messages-1.45.0.tgz#63eb9e9b5c7356a84b82eea202c0a031b49a1358"
-  integrity sha512-QdsGGRIeZBi6VNsR4rzFw5v1O4xYwfmwEoOUCXWE3gjoqEyyJvCyUehjHPke/5IVyGuYyO0NL9SsuxodF5gUvw==
+"@theia/messages@1.45.1":
+  version "1.45.1"
+  resolved "https://registry.yarnpkg.com/@theia/messages/-/messages-1.45.1.tgz#6de906d2812a7b8d79b45ec52f234f8a7a3c9e3e"
+  integrity sha512-s4hR5CsbblRIBschT6eogUdMeJxOEPJ22QYwD0QDSWvOLd93TgDadzgyrSaj2mkVrAT39+2ty53vm3Mp1bMbrQ==
   dependencies:
-    "@theia/core" "1.45.0"
+    "@theia/core" "1.45.1"
     react-perfect-scrollbar "^1.5.3"
     ts-md5 "^1.2.2"
 
@@ -2174,128 +2174,128 @@
   resolved "https://registry.yarnpkg.com/@theia/monaco-editor-core/-/monaco-editor-core-1.72.3.tgz#911d674c6e0c490442a355cfaa52beec919a025e"
   integrity sha512-2FK5m0G5oxiqCv0ZrjucMx5fVgQ9Jqv0CgxGvSzDc4wRrauBdeBoX90J99BEIOJ8Jp3W0++GoRBdh0yQNIGL2g==
 
-"@theia/monaco@1.45.0":
-  version "1.45.0"
-  resolved "https://registry.yarnpkg.com/@theia/monaco/-/monaco-1.45.0.tgz#64d3a7a0f4177715e2753d9c88e14b5709932fa5"
-  integrity sha512-6qzLGLyy81K4yFjJ848CQ0in63nymF1nV+tSCYt8yz3r/GIYxVnzaxgZ1PsC76BjH+FxgZxN/U3TgssY/9SP/Q==
+"@theia/monaco@1.45.1":
+  version "1.45.1"
+  resolved "https://registry.yarnpkg.com/@theia/monaco/-/monaco-1.45.1.tgz#1fd09e9fcc6faecba82572ccf854973e0b84e1bd"
+  integrity sha512-8yhTv1VRnjnPzPVBoWQadcfjnzSme96ODeqbza228NYDD4LEaPrYKYZMX0AJMZY/vOR9qmbrtcWmUS55hIemDQ==
   dependencies:
-    "@theia/core" "1.45.0"
-    "@theia/editor" "1.45.0"
-    "@theia/filesystem" "1.45.0"
-    "@theia/markers" "1.45.0"
+    "@theia/core" "1.45.1"
+    "@theia/editor" "1.45.1"
+    "@theia/filesystem" "1.45.1"
+    "@theia/markers" "1.45.1"
     "@theia/monaco-editor-core" "1.72.3"
-    "@theia/outline-view" "1.45.0"
-    "@theia/workspace" "1.45.0"
+    "@theia/outline-view" "1.45.1"
+    "@theia/workspace" "1.45.1"
     fast-plist "^0.1.2"
     idb "^4.0.5"
     jsonc-parser "^2.2.0"
     vscode-oniguruma "1.6.1"
     vscode-textmate "^9.0.0"
 
-"@theia/native-webpack-plugin@1.45.0":
-  version "1.45.0"
-  resolved "https://registry.yarnpkg.com/@theia/native-webpack-plugin/-/native-webpack-plugin-1.45.0.tgz#95421566084249d2bd40ac8089947eb1f5f8b8d3"
-  integrity sha512-ISSMJpkPZFVWcH4kr1ASyp55VRbrh8dSo0eZ0Zv9CU0axtspDtYE5dc3HzGwsp7F+aARtSDpoAFXKDqD0Ybsxg==
+"@theia/native-webpack-plugin@1.45.1":
+  version "1.45.1"
+  resolved "https://registry.yarnpkg.com/@theia/native-webpack-plugin/-/native-webpack-plugin-1.45.1.tgz#9fa372174bf77775ac1ab183b66a6091bb47b640"
+  integrity sha512-Abqhrgah7xAI8h9oMmOx3KIT9s5YzET8SSss6CCo/NA7wULbgBt7Tvl8pTJBbjxMYtn+6QeX400s9USJDs0eYQ==
   dependencies:
     webpack "^5.76.0"
 
-"@theia/navigator@1.45.0":
-  version "1.45.0"
-  resolved "https://registry.yarnpkg.com/@theia/navigator/-/navigator-1.45.0.tgz#23d1cc8345a1b6d68de85c676b8b7cd2ab217061"
-  integrity sha512-nkpeSChHZQPIEIL0EQYSqnh8krqknh/jTB3ThZnH9AfH8r6iccpz/d1bPaoAoR9fyufXRIZqg7gLCbp4whpjIA==
+"@theia/navigator@1.45.1":
+  version "1.45.1"
+  resolved "https://registry.yarnpkg.com/@theia/navigator/-/navigator-1.45.1.tgz#9a14afb31eef5612ab8d1a5e819af20089502e3a"
+  integrity sha512-047ZKlGw1eqWBqkw0pOa2L2o4i1jPf3j122qLfzuJng2ArTtbuhGdlYaG9uAk3zaJ5TFoRHA6ta57VTEVUjNrw==
   dependencies:
-    "@theia/core" "1.45.0"
-    "@theia/filesystem" "1.45.0"
-    "@theia/workspace" "1.45.0"
+    "@theia/core" "1.45.1"
+    "@theia/filesystem" "1.45.1"
+    "@theia/workspace" "1.45.1"
     minimatch "^5.1.0"
 
-"@theia/outline-view@1.45.0":
-  version "1.45.0"
-  resolved "https://registry.yarnpkg.com/@theia/outline-view/-/outline-view-1.45.0.tgz#b850599ed8f7e346cf2e0c539f627d613663fb0b"
-  integrity sha512-PiXmBLe8LRk/jMLWs+51SdA7WhTky6OsIylLQ726SI60h0STie9NoLP3MvkNHC120yaQUbJm3x3L/m4yjF/wVw==
+"@theia/outline-view@1.45.1":
+  version "1.45.1"
+  resolved "https://registry.yarnpkg.com/@theia/outline-view/-/outline-view-1.45.1.tgz#1c44f1636b3b71f9c989448fbbf2e630f7ef07f8"
+  integrity sha512-umSYy0NU2hvrIfYsar6dbp58JVNWbk1mbCjHlZmy5y7V+9/vwxIMWXG6tuM/b/B8TPYWeY6fg1U6JRi6d921Rw==
   dependencies:
-    "@theia/core" "1.45.0"
+    "@theia/core" "1.45.1"
 
-"@theia/ovsx-client@1.45.0":
-  version "1.45.0"
-  resolved "https://registry.yarnpkg.com/@theia/ovsx-client/-/ovsx-client-1.45.0.tgz#bfc7d3fefe5db66779559e740f316ef367908470"
-  integrity sha512-oguhhJNpwNyesNZRrRWYGfVCGRe6HQkvf+SdaUN4LvJwC4jXF82/OOolU6VptcPzsrDH/mFPAMVfL78o2W9vcQ==
+"@theia/ovsx-client@1.45.1":
+  version "1.45.1"
+  resolved "https://registry.yarnpkg.com/@theia/ovsx-client/-/ovsx-client-1.45.1.tgz#368e3d5435e82963eeb39c321cf0be4f77ca165e"
+  integrity sha512-08yUWTYXQSNcXZG1XYbxMC5z4ydUHYoKSEHJhDD+ShDnagOymQa77xdSjebAL50KkuDxXkux44s+sR1im5euFg==
   dependencies:
-    "@theia/request" "1.45.0"
+    "@theia/request" "1.45.1"
     semver "^7.5.4"
 
-"@theia/preferences@1.45.0":
-  version "1.45.0"
-  resolved "https://registry.yarnpkg.com/@theia/preferences/-/preferences-1.45.0.tgz#5b377b8238656fa57914976bb0d34c22d92ae06c"
-  integrity sha512-BPL5Kbg1s7q0Vx+9vYBqD2njjmOVTXYSPDh6MKx/I73e85TlxCCUfFh/TqmcFmS1OMIgYg5PwMvDGNP6bbv44g==
+"@theia/preferences@1.45.1":
+  version "1.45.1"
+  resolved "https://registry.yarnpkg.com/@theia/preferences/-/preferences-1.45.1.tgz#3e4859f588212c2016bedae37f8bdf01fdff35f3"
+  integrity sha512-TJyl0xx06s8L6VX/vG1k5tqgo0OtTsqI4lIs3Fj3dta/yl6ekJ3wvTO3J0tFddmXWxK6ATiTjgK7hZ9ChHA9ug==
   dependencies:
-    "@theia/core" "1.45.0"
-    "@theia/editor" "1.45.0"
-    "@theia/filesystem" "1.45.0"
-    "@theia/monaco" "1.45.0"
+    "@theia/core" "1.45.1"
+    "@theia/editor" "1.45.1"
+    "@theia/filesystem" "1.45.1"
+    "@theia/monaco" "1.45.1"
     "@theia/monaco-editor-core" "1.72.3"
-    "@theia/userstorage" "1.45.0"
-    "@theia/workspace" "1.45.0"
+    "@theia/userstorage" "1.45.1"
+    "@theia/workspace" "1.45.1"
     async-mutex "^0.3.1"
     fast-deep-equal "^3.1.3"
     jsonc-parser "^2.2.0"
     p-debounce "^2.1.0"
 
-"@theia/process@1.45.0":
-  version "1.45.0"
-  resolved "https://registry.yarnpkg.com/@theia/process/-/process-1.45.0.tgz#a5e6bd01ecfe5a644028e50ee1edc34e23db9881"
-  integrity sha512-RRqt6KmLc4ahO5+pEBrfFYnBwp+NlUXLarfT6nnUP+ILGPJpMf5S65xGecrz0BLRynDV9E9d4xyAXE1gYYS9fA==
+"@theia/process@1.45.1":
+  version "1.45.1"
+  resolved "https://registry.yarnpkg.com/@theia/process/-/process-1.45.1.tgz#171c84977272fe6fbc2d75a3b990be5440901fa5"
+  integrity sha512-WmAjgc47mcc2flxG+bvrlk+dMmkpVIe5k7yUnruKx+DtJedYXf0MqdaZSEX6FRHHRyGzlmuQS3KJbf5uQ2BD1w==
   dependencies:
-    "@theia/core" "1.45.0"
+    "@theia/core" "1.45.1"
     node-pty "0.11.0-beta17"
     string-argv "^0.1.1"
 
-"@theia/request@1.45.0":
-  version "1.45.0"
-  resolved "https://registry.yarnpkg.com/@theia/request/-/request-1.45.0.tgz#f16ed97a488dacdbb62532c3743af5da49ffb15b"
-  integrity sha512-wAu69y3XFoCLWp2aZA5jFM+P7K9dOjzinE2hIyw1CdQC4N8/Y9Zs6b2aBiAHjqAf3lfBUN4oYJi0isetOfQpyg==
+"@theia/request@1.45.1":
+  version "1.45.1"
+  resolved "https://registry.yarnpkg.com/@theia/request/-/request-1.45.1.tgz#fb2d39cf771d8b63bb04189a9b3c739910548250"
+  integrity sha512-IBTQ2bN6Y+jWpruYfzq9I+t8OaGGg8cQar0PimibnPwg2f7XmOIf3NmkTh1JO+oiBjBm0Yv0t33A2oQ8Yhy5qw==
   dependencies:
     http-proxy-agent "^5.0.0"
     https-proxy-agent "^5.0.0"
 
-"@theia/terminal@1.45.0":
-  version "1.45.0"
-  resolved "https://registry.yarnpkg.com/@theia/terminal/-/terminal-1.45.0.tgz#374c9993dc1d6cb10f4c1319a7bcde307b58e4df"
-  integrity sha512-kZkhN0R9MPFDRJybQ8iHRShcpDyRX5mxn2AklFw4JDM4dtvQbA9Io8hnaOHDNHnvh5OLf7tOnT/yWAvBnZ7khg==
+"@theia/terminal@1.45.1":
+  version "1.45.1"
+  resolved "https://registry.yarnpkg.com/@theia/terminal/-/terminal-1.45.1.tgz#ef5d8471eed0d0dbdc1099b8dfb9eaa1b7be5967"
+  integrity sha512-93RAkLA3tW0dmdIBT/PmU6JKxEd30sHbIKzojLHkU/XLozZrBzESmPX8b9NmoHw5oFzTAMx+dSSPFxS8H2WnOw==
   dependencies:
-    "@theia/core" "1.45.0"
-    "@theia/editor" "1.45.0"
-    "@theia/filesystem" "1.45.0"
-    "@theia/process" "1.45.0"
-    "@theia/variable-resolver" "1.45.0"
-    "@theia/workspace" "1.45.0"
+    "@theia/core" "1.45.1"
+    "@theia/editor" "1.45.1"
+    "@theia/filesystem" "1.45.1"
+    "@theia/process" "1.45.1"
+    "@theia/variable-resolver" "1.45.1"
+    "@theia/workspace" "1.45.1"
     xterm "^4.16.0"
     xterm-addon-fit "^0.5.0"
     xterm-addon-search "^0.8.2"
 
-"@theia/userstorage@1.45.0":
-  version "1.45.0"
-  resolved "https://registry.yarnpkg.com/@theia/userstorage/-/userstorage-1.45.0.tgz#ac90522cc56913ce0a9e2c31f2a1623aff150f7c"
-  integrity sha512-a5C47mFR4OS/CUVdUEUwgTk412s/2BmQ8/zWpEcFsVlW2ZzUWFxEa+mko3Fd+QwH1v7Sj6cJafmUvESNMgFmqg==
+"@theia/userstorage@1.45.1":
+  version "1.45.1"
+  resolved "https://registry.yarnpkg.com/@theia/userstorage/-/userstorage-1.45.1.tgz#c42f7f37a72bc8ae78b4762d4c705ba5064c2d8d"
+  integrity sha512-wHz9XT+pfo8G1vVpe53XhMJsAb8I4MCuQby0HRA3Mf0usCYChJ7gHS9JiKlY1W5f/Nv8C91uP7RztK2vu7KNOA==
   dependencies:
-    "@theia/core" "1.45.0"
-    "@theia/filesystem" "1.45.0"
+    "@theia/core" "1.45.1"
+    "@theia/filesystem" "1.45.1"
 
-"@theia/variable-resolver@1.45.0":
-  version "1.45.0"
-  resolved "https://registry.yarnpkg.com/@theia/variable-resolver/-/variable-resolver-1.45.0.tgz#ad663c7e0734799c310b6e7576308b890f17bc3c"
-  integrity sha512-FtHaWFvznOroX7hlGMcsrxnf+bt8td07xYQqzVmTRZf6HDJg0bPTjBXwxbtMbKr0wxSQVPKp2w8PYK7J3McH/Q==
+"@theia/variable-resolver@1.45.1":
+  version "1.45.1"
+  resolved "https://registry.yarnpkg.com/@theia/variable-resolver/-/variable-resolver-1.45.1.tgz#dbce68493667e2a38001ff6e45122a4d16cc296f"
+  integrity sha512-4guRHsnwct6kbnJLwZfZIb2EDcxvqqAUeafkIktPDg5VojrClnVa/yjaehPY+XXAqfZQul4daNe/lIMRwCljTQ==
   dependencies:
-    "@theia/core" "1.45.0"
+    "@theia/core" "1.45.1"
 
-"@theia/workspace@1.45.0":
-  version "1.45.0"
-  resolved "https://registry.yarnpkg.com/@theia/workspace/-/workspace-1.45.0.tgz#c406b3239d3e3cca573a019f71e458b0362f609e"
-  integrity sha512-x1+t4hKt+2zH7UugD5MjnpRfFG6itK9hVNx0D33rd8WKOI+Q/VuuA6RM6qpmQ5jVPnqTVX2mXrMVC4ZGKHUyQQ==
+"@theia/workspace@1.45.1":
+  version "1.45.1"
+  resolved "https://registry.yarnpkg.com/@theia/workspace/-/workspace-1.45.1.tgz#62f43189f5836f48119d906c96c471d59317563c"
+  integrity sha512-TiCmhQLS0VNQVH1ckF6Z+3MoR2y/BcWF81sHbC8k7VFQrLuhzUJzPav77kMRte4XGs0ThXCyuCeV/Xy4FmK1Gw==
   dependencies:
-    "@theia/core" "1.45.0"
-    "@theia/filesystem" "1.45.0"
-    "@theia/variable-resolver" "1.45.0"
+    "@theia/core" "1.45.1"
+    "@theia/filesystem" "1.45.1"
+    "@theia/variable-resolver" "1.45.1"
     jsonc-parser "^2.2.0"
     valid-filename "^2.0.1"
 


### PR DESCRIPTION
Fix API breaks introduced with Theia 1.44.
Update `Theia Version Compatibility` section in README.md.
Note that mentioned `2.1.0-theia1.44.0 ` version is not released yet.
I will do so once this change is approved.