### PR TITLE
77: BaseGLSPClient should handle reconnect

### DIFF
--- a/examples/browser-app/package.json
+++ b/examples/browser-app/package.json
@@ -30,6 +30,16 @@
     "@theia/cli": "1.45.1"
   },
   "theia": {
-    "target": "browser"
+    "target": "browser",
+    "frontend": {
+      "config": {
+        "reloadOnReconnect": true
+      }
+    },
+    "backend": {
+      "config": {
+        "frontendConnectionTimeout": 86400000
+      }
+    }
   }
 }

--- a/packages/theia-integration/src/browser/glsp-client-contribution.ts
+++ b/packages/theia-integration/src/browser/glsp-client-contribution.ts
@@ -195,7 +195,7 @@ export abstract class BaseGLSPClientContribution implements GLSPClientContributi
                         resolve(connection);
                     }
                 },
-                false
+                true
             );
         });
     }


### PR DESCRIPTION
- update to Theia 1.45
- enable support for reconnect with a 24h timeout in the example browser-app
- contribute an example command to test the reconnect behavior (as defined in https://github.com/eclipse-theia/theia/pull/13082)
  - ~~We probably don't want to actually push this command, so I added it as a separate commit. We might want to revert it before actually merging anything.~~

Note: once the update to Theia 1.45 is in, the only required change is a Theia config option in the application, to actually enable the behavior. I don't think any change in required in GLSP itself. Typically, we want a relatively short timeout for Browser Application (especially if they are deployed to the cloud), to avoid large memory leaks, and an infinite timeout (-1) for Electron applications, as we only ever expect a single connection. I chose a 24-hours timeout, which is pretty long, because this is an example application that is typically deployed locally for testing; so we're closer to the Electron scenario (single user local deployment) than a regular web-app.

Part of https://github.com/eclipse-glsp/glsp/issues/77