### PR TITLE
GLSP-1302 Fix ServiceConnectionProvider inject in GLSPClientContribution

### DIFF
--- a/packages/theia-integration/src/browser/glsp-client-contribution.ts
+++ b/packages/theia-integration/src/browser/glsp-client-contribution.ts
@@ -25,7 +25,7 @@ import {
 } from '@eclipse-glsp/client';
 import { Disposable, DisposableCollection, MessageService } from '@theia/core';
 import { FrontendApplication } from '@theia/core/lib/browser';
-import { ServiceConnectionProvider } from '@theia/core/lib/browser/messaging/service-connection-provider';
+import { RemoteConnectionProvider, ServiceConnectionProvider } from '@theia/core/lib/browser/messaging/service-connection-provider';
 import { Deferred } from '@theia/core/lib/common/promise-util';
 import { inject, injectable } from '@theia/core/shared/inversify';
 import { MessageConnection } from 'vscode-jsonrpc';
@@ -111,7 +111,7 @@ export abstract class BaseGLSPClientContribution implements GLSPClientContributi
     }
 
     @inject(MessageService) protected readonly messageService: MessageService;
-    @inject(ServiceConnectionProvider)
+    @inject(RemoteConnectionProvider)
     protected readonly connectionProvider: ServiceConnectionProvider;
 
     get glspClient(): Promise<GLSPClient> {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-glsp/glsp/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See [SECURITY.md](https://github.com/eclipse-glsp/glsp/blob/master/SECURITY.md),
to learn how to report vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

Resolve this binding issue by using the RemoteConnectionProvider Symbol to inject, as it is bound to the ServiceConnectionProvider, to ensure it working for both use cases (browser and electron).

Resolves https://github.com/eclipse-glsp/glsp/issues/1302

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- To test, both browser and electron application should be tested to verify the standard functionality still works as expected.
- For the electron use case, this WIP branch can be used: https://github.com/eclipse-glsp/glsp-theia-integration/tree/issues/1303

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

--

#### Changelog

<!-- Please check, when if it applies to your change. -->

- [ ] This PR should be mentioned in the changelog
- [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)
