### PR TITLE
GLSP-1308: Ensure that the hidden div is properly removed  on close

### DIFF
--- a/packages/theia-integration/src/browser/diagram/glsp-diagram-widget.ts
+++ b/packages/theia-integration/src/browser/diagram/glsp-diagram-widget.ts
@@ -254,6 +254,7 @@ export class GLSPDiagramWidget extends BaseWidget implements SaveableSource, Sta
         this.storeViewportDataInStorageService();
         this.node.removeEventListener('mouseenter', this.handleMouseEnter);
         this.node.removeEventListener('mouseleave', this.handleMouseLeave);
+        document.querySelector(`#${this.viewerOptions.hiddenDiv}`)?.remove();
         super.onBeforeDetach(msg);
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-glsp/glsp/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See [SECURITY.md](https://github.com/eclipse-glsp/glsp/blob/master/SECURITY.md),
to learn how to report vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->
Ensure that the hidden div is properly removed when a diagram is closed.
The hidden div is purposely part of the document body and not the diagram root itself
This ensures that the hidden computation also works as expected if the diagram is currently hidden 
e.g. because another tab is in focus
However, this also means that we have to cleanup the hidden div when the diagram closes i.e. is detached.
Contributed on behalf of STMicroelectronics
Fixes https://github.com/eclipse-glsp/glsp/issues/1308

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Open & close a diagram editor. Ensure that both the diagram div and the hidden div are no longer part of the dom after closing.
#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Changelog

<!-- Please check, when if it applies to your change. -->

- [x] This PR should be mentioned in the changelog
- [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)
