### PR TITLE
GLSP-1354: Improve viewport restore on diagram open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,11 @@
 -   [rpc] Ensure that the GLSP client properly reconnects to the backend after a temporary connection loss [#197](https://github.com/eclipse-glsp/glsp-theia-integration/pull/197) [#203](https://github.com/eclipse-glsp/glsp-theia-integration/pull/203)
 -   [diagram] Fix a bug that prevented proper disposal of the hidden diagram div after closing a diagram editor [#204](https://github.com/eclipse-glsp/glsp-theia-integration/pull/204)
 -   [diagram] Improve `createDiagramWidgetFactory` utility function to also support factories for GLSPDiagramWidget subclasses [#211](https://github.com/eclipse-glsp/glsp-theia-integration/pull/211)
+-   [diagram] Ensure that viewport restore on diagram open works generically indecently of how the diagram widget has been created [#218](https://github.com/eclipse-glsp/glsp-theia-integration/pull/218)
 
 ### Potentially Breaking Changes
 
--   [launch] Changed the `GLSPServerContributionOptions.debugArgument` from `debug` to `glspDebug` to avoid clashes with nodes `debug` argument. Launch configurations and scripts need to be updated accordingly. [#211](https://github.com/eclipse-glsp/glsp-theia-integration/pull/211)
+-   [launch] Changed the `GLSPServerContributionOptions.debugArgument` from `debug` to `glspDebug` to avoid clashes with nodes `debug` argument. Launch configurations and scripts need to be updated accordingly [#211](https://github.com/eclipse-glsp/glsp-theia-integration/pull/211)
 
 ## [2.1.0- 24/01/2024](https://github.com/eclipse-glsp/glsp-theia-integration/releases/tag/v2.1.0)
 

--- a/packages/theia-integration/src/browser/diagram/glsp-diagram-manager.ts
+++ b/packages/theia-integration/src/browser/diagram/glsp-diagram-manager.ts
@@ -1,6 +1,6 @@
 /********************************************************************************
  * Copyright (c) 2018-2018 TypeFox and others.
- * Modifications: (c) 2019-2023 EclipseSource and others.
+ * Modifications: (c) 2019-2024 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -70,7 +70,6 @@ export abstract class GLSPDiagramManager extends WidgetOpenHandler<GLSPDiagramWi
     protected widgetCount = 0;
 
     override async doOpen(widget: GLSPDiagramWidget, maybeOptions?: WidgetOpenerOptions): Promise<void> {
-        const widgetWasAttached = widget.isAttached;
         const options: WidgetOpenerOptions = {
             mode: 'activate',
             ...maybeOptions
@@ -86,9 +85,6 @@ export abstract class GLSPDiagramManager extends WidgetOpenHandler<GLSPDiagramWi
         }
         if (this.handleNavigations(widget, options)) {
             return;
-        }
-        if (!widgetWasAttached && widget instanceof GLSPDiagramWidget) {
-            widget.restoreViewportDataFromStorageService();
         }
     }
 


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-glsp/glsp/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See [SECURITY.md](https://github.com/eclipse-glsp/glsp/blob/master/SECURITY.md),
to learn how to report vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->
Move viewport restoration logic from the diagram manager to the `onAfterAttach` method of the diagram widget. This ensures that the viewport restoration allways works independently of how the diagram has been created (WidgetOpenHandler vs. direct creation). Fixes https://github.com/eclipse-glsp/glsp/issues/1354

Also
- Move `RequestModelOptions` generation into a submethod for easier extendibility
- Register the mouse enter/mouse leave listeners via the `addEventListener` utility method which already has built-in dispose on detach behavior

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Changelog

<!-- Please check, when if it applies to your change. -->

-   [ ] This PR should be mentioned in the changelog
-   [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)
