### PR TITLE
Revert "V2.2.0"

### DIFF
--- a/.github/workflows/theia-compat.yml
+++ b/.github/workflows/theia-compat.yml
@@ -2,6 +2,8 @@ name: Theia Compatibility
 
 on:
   workflow_dispatch:
+  pull_request:
+    branches: [master]
   schedule:
     - cron: '0 8 * * 1' # Every Monday at 8 AM UTC
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Eclipse GLSP Theia Integration Changelog
 
-## [2.2.0- 04/07/2024](https://github.com/eclipse-glsp/glsp-theia-integration/releases/tag/v2.2.0)
+## 2.2.0 - active
 
 ### Changes
 
@@ -8,7 +8,6 @@
 -   [diagram] Fix a bug that prevented proper disposal of the hidden diagram div after closing a diagram editor [#204](https://github.com/eclipse-glsp/glsp-theia-integration/pull/204)
 -   [diagram] Improve `createDiagramWidgetFactory` utility function to also support factories for GLSPDiagramWidget subclasses [#211](https://github.com/eclipse-glsp/glsp-theia-integration/pull/211)
 -   [diagram] Ensure that viewport restore on diagram open works generically indecently of how the diagram widget has been created [#218](https://github.com/eclipse-glsp/glsp-theia-integration/pull/218)
--   [api] Update `GLSPSaveable` to be compliant with the API changes of Theia 1.50.0. Include a backwards compatibility layer for Theia < 1.50.0 [#220](https://github.com/eclipse-glsp/glsp-theia-integration/pull/220)
 
 ### Potentially Breaking Changes
 

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ For details on building the project, please see the [README file of the theia-in
 | 2.0.0                           | >=1.39.0 < 1.45.0  |
 | 2.1.x                           | >=1.39.0 < 1.45.0  |
 | 2.1.0-theia1.45.0               | >=1.45.0 < 1.50.0  |
-| 2.1.0-theia1.50.0               | >=1.45.0           |
-| next                            | >=1.45.0           |
+| 2.1.0-theia1.50.0               | >=1.50.0           |
+| next                            | >=1.50.0           |
 
 > Note: For versions <=1.0.0 it is not possible to safely restrict the maximum version of Theia packages. If you encounter build errors related to multiple resolved Theia versions please add a resolutions block to the `package.json` of your project e.g. for `1.0.0-theia1.27.0`:
 

--- a/examples/browser-app/package.json
+++ b/examples/browser-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browser-app",
-  "version": "2.2.0",
+  "version": "2.2.0-next",
   "private": true,
   "scripts": {
     "build": "yarn rebuild && theia build --mode development",
@@ -14,7 +14,7 @@
     "watch": "theia build --watch --mode development"
   },
   "dependencies": {
-    "@eclipse-glsp-examples/workflow-theia": "2.2.0",
+    "@eclipse-glsp-examples/workflow-theia": "2.2.0-next",
     "@theia/core": "~1.49.1",
     "@theia/editor": "~1.49.1",
     "@theia/filesystem": "~1.49.1",

--- a/examples/electron-app/package.json
+++ b/examples/electron-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-app",
-  "version": "2.2.0",
+  "version": "2.2.0-next",
   "private": true,
   "main": "lib/backend/electron-main.js",
   "scripts": {
@@ -15,7 +15,7 @@
     "watch": "theia build --watch --mode development"
   },
   "dependencies": {
-    "@eclipse-glsp-examples/workflow-theia": "2.2.0",
+    "@eclipse-glsp-examples/workflow-theia": "2.2.0-next",
     "@theia/core": "~1.49.1",
     "@theia/editor": "~1.49.1",
     "@theia/electron": "~1.49.1",

--- a/examples/workflow-theia/package.json
+++ b/examples/workflow-theia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-glsp-examples/workflow-theia",
-  "version": "2.2.0",
+  "version": "2.2.0-next",
   "private": "true",
   "description": "Theia extension for the workflow GLSP example",
   "keywords": [
@@ -34,10 +34,10 @@
     "watch": "tsc -w"
   },
   "dependencies": {
-    "@eclipse-glsp-examples/workflow-glsp": "2.2.0",
-    "@eclipse-glsp-examples/workflow-server": "2.2.0",
-    "@eclipse-glsp-examples/workflow-server-bundled": "2.2.0",
-    "@eclipse-glsp/theia-integration": "2.2.0"
+    "@eclipse-glsp-examples/workflow-glsp": "next",
+    "@eclipse-glsp-examples/workflow-server": "next",
+    "@eclipse-glsp-examples/workflow-server-bundled": "next",
+    "@eclipse-glsp/theia-integration": "2.2.0-next"
   },
   "publishConfig": {
     "access": "public"

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.2.0",
+  "version": "2.1.0",
   "npmClient": "yarn",
   "command": {
     "run": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parent",
-  "version": "2.2.0",
+  "version": "2.1.0",
   "private": true,
   "workspaces": [
     "packages/theia-integration",
@@ -30,7 +30,7 @@
     "watch:electron": "concurrently --kill-others -n tsc,browser -c red,yellow \"tsc -b -w --preserveWatchOutput\" \"yarn -s electron watch\""
   },
   "devDependencies": {
-    "@eclipse-glsp/dev": "2.2.0",
+    "@eclipse-glsp/dev": "next",
     "@types/node": "16.x",
     "concurrently": "^8.2.2",
     "lerna": "^7.0.0",

--- a/packages/theia-integration/README.md
+++ b/packages/theia-integration/README.md
@@ -16,8 +16,8 @@ This project is built with `yarn` and is available from npm via [@eclipse-glsp/t
 | 2.0.0                           | >=1.39.0 < 1.45.0  |
 | 2.1.x                           | >=1.39.0 < 1.45.0  |
 | 2.1.0-theia1.45.0               | >=1.45.0 < 1.50.0  |
-| 2.1.0-theia1.50.0               | >=1.45.0           |
-| next                            | >=1.45.0           |
+| 2.1.0-theia1.50.0               | >=1.50.0           |
+| next                            | >=1.50.0           |
 
 > Note: For versions <=1.0.0 it is not possible to safely restrict the maximum version of Theia packages. If you encounter build errors related to multiple resolved Theia versions please add a resolutions block to the `package.json` of your project e.g. for `1.0.0-theia1.27.0`:
 

--- a/packages/theia-integration/package.json
+++ b/packages/theia-integration/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-glsp/theia-integration",
-  "version": "2.2.0",
+  "version": "2.2.0-next",
   "description": "Glue code to integrate GLSP clients into Eclipse Theia",
   "keywords": [
     "theia-extension",
@@ -43,8 +43,8 @@
     "watch": "tsc -w"
   },
   "dependencies": {
-    "@eclipse-glsp/client": "2.2.0",
-    "ws": "^8.11.0"
+    "@eclipse-glsp/client": "next",
+    "ws": "~8.11.0"
   },
   "devDependencies": {
     "@types/ws": "^8.5.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -989,32 +989,32 @@
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
   integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==
 
-"@eclipse-glsp-examples/workflow-glsp@2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp-examples/workflow-glsp/-/workflow-glsp-2.2.0.tgz#3a7587d0becdc49798c6a5b7baf80fe27ef8d952"
-  integrity sha512-PDn1/WZK8JktZl3GeOHOw0KMJkCPAS/EVF0q3WNnQ6pQj00WO4lGDxgY5jAwIbXumPNkZx32BbNFI2Ekrd4qdA==
+"@eclipse-glsp-examples/workflow-glsp@next":
+  version "2.2.0-next.353"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp-examples/workflow-glsp/-/workflow-glsp-2.2.0-next.353.tgz#c2c5db314649d869d1a5d0121232c920c7bc9668"
+  integrity sha512-gG5R1OCby32uqSSTtVBk5lR/G+/gV/6ZZgaBgATTUKspYMXqizFUvPlVIVvpzzkoMKH5taHopBRgw5/K2TfqaA==
   dependencies:
-    "@eclipse-glsp/client" "2.2.0"
+    "@eclipse-glsp/client" "2.2.0-next.353+1e0d319"
     balloon-css "^0.5.0"
 
-"@eclipse-glsp-examples/workflow-server-bundled@2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp-examples/workflow-server-bundled/-/workflow-server-bundled-2.2.0.tgz#5ec3b97c90006b52b337e3c4acf525c4b9c8232a"
-  integrity sha512-F7vAkEECVqMVf//zm9jQycwMSeZc/eeLJtk/KLS01YFVdw1t09oO2qiK4NZIdp9V2IyDIhctRGm7Z5ohRZMONw==
+"@eclipse-glsp-examples/workflow-server-bundled@next":
+  version "2.2.0-next.94"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp-examples/workflow-server-bundled/-/workflow-server-bundled-2.2.0-next.94.tgz#dda22d89c6525a026991976e3388aa7bd4f9ed1c"
+  integrity sha512-0LYtbXYWXjfZL3RgQeUemvscR26hm9KTj1WMw6tkfWvMyD0zfFpxBVTczswW0fEDEivXcYBIJ+fB+Jp3MGkm9w==
 
-"@eclipse-glsp-examples/workflow-server@2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp-examples/workflow-server/-/workflow-server-2.2.0.tgz#49d1d1ab784a997c2ec752d6fd309adcfe1a8290"
-  integrity sha512-HtCy/lHHkz9DGihqWkJqHGD9jD0X/GKAzJgBhpaM4+gqutpc4gkvyFll54UsqtyN5tsBpWy4UIl/B0qmVCK63A==
+"@eclipse-glsp-examples/workflow-server@next":
+  version "2.2.0-next.94"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp-examples/workflow-server/-/workflow-server-2.2.0-next.94.tgz#2c5fac891d6e3c6bc589ac25cad1004d933fc943"
+  integrity sha512-fGRGJxxW7Ngf6HmjcfWxEtJRzleqA0XQIJ/D/mu7Nnzn1SQDhFZCw62ltc/HoBGQfopoQ6yoUf/eR6XNrgkfuA==
   dependencies:
-    "@eclipse-glsp/layout-elk" "2.2.0"
-    "@eclipse-glsp/server" "2.2.0"
-    inversify "^6.0.2"
+    "@eclipse-glsp/layout-elk" "2.2.0-next.94+d7e90ed"
+    "@eclipse-glsp/server" "2.2.0-next.94+d7e90ed"
+    inversify "^6.0.1"
 
-"@eclipse-glsp/cli@2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp/cli/-/cli-2.2.0.tgz#1f9659c2ee05739d167f1c40ab79c689e56967d6"
-  integrity sha512-bR/Wb3cvJRA1LcghYEJAG9PB3Dc4NLYrl75lCmjsyWzl8RXoxKfTTCgFoCmFRZdxtkufMr3kQZirnRCyjeVl6w==
+"@eclipse-glsp/cli@2.2.0-next.c32aadb.160+c32aadb":
+  version "2.2.0-next.c32aadb.160"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp/cli/-/cli-2.2.0-next.c32aadb.160.tgz#1171b21aec7bddfcc73e68cc41d0b9dcb199c258"
+  integrity sha512-Clw0YKkMg41vQnd3UY9quIConKdQoQ98+dp15ouKps5yG8l3xpmjCC44V10N4LJ5l2Jmol6UTJfPGmA9FyrGdw==
   dependencies:
     commander "^10.0.1"
     glob "^10.3.10"
@@ -1025,25 +1025,25 @@
     semver "^7.5.1"
     shelljs "^0.8.5"
 
-"@eclipse-glsp/client@2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp/client/-/client-2.2.0.tgz#705c4bb94955cec7fee56329a3eb5804c0500589"
-  integrity sha512-zIXIbqeEIjadIO8uOf6z9SOBek3TWJB7R8CUIHFyKYcLnIPMm/rqMMeUNQIerIPvWbtP9g/ulqXpgk+NNisyVQ==
+"@eclipse-glsp/client@2.2.0-next.353+1e0d319", "@eclipse-glsp/client@next":
+  version "2.2.0-next.353"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp/client/-/client-2.2.0-next.353.tgz#685ab9c04a01251a8961c9849c778d99c4378946"
+  integrity sha512-+LrF3WXNGaJ+OL/+sY+7cMpG24B3Vzu4FHEwgTQSRGlulu7EpUq4jy9vdSQH/FxAk1s+chIKc2y/rTo7fBoi0w==
   dependencies:
-    "@eclipse-glsp/sprotty" "2.2.0"
+    "@eclipse-glsp/sprotty" "2.2.0-next.353+1e0d319"
     autocompleter "^9.1.2"
     file-saver "^2.0.5"
     lodash "4.17.21"
     snabbdom "~3.5.1"
     vscode-jsonrpc "8.2.0"
 
-"@eclipse-glsp/config-test@2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp/config-test/-/config-test-2.2.0.tgz#a4e108463a98ee5be2946682ff2624f36a073ce1"
-  integrity sha512-rRzZUNsT8p9vkGWqfaHNZg+4x7oIYfMfPP40BUx4lktch+riETkGdsdtecWs9K8TYOLx+SWSaq6hfyZl3832Dw==
+"@eclipse-glsp/config-test@2.2.0-next.c32aadb.160+c32aadb":
+  version "2.2.0-next.c32aadb.160"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp/config-test/-/config-test-2.2.0-next.c32aadb.160.tgz#30f409221024544604f5030caf092ac89d22867d"
+  integrity sha512-STBp0y+SmvpWz+D8wdyiVMelE7jFAGVxicFekalmoNaDO3pUSR3QmuxGHsSwWQ3qOB30vic4eMc3rSMrR4dABw==
   dependencies:
-    "@eclipse-glsp/mocha-config" "2.2.0"
-    "@eclipse-glsp/nyc-config" "2.2.0"
+    "@eclipse-glsp/mocha-config" "2.2.0-next.c32aadb.160+c32aadb"
+    "@eclipse-glsp/nyc-config" "2.2.0-next.c32aadb.160+c32aadb"
     "@istanbuljs/nyc-config-typescript" "^1.0.2"
     "@types/chai" "^4.3.7"
     "@types/mocha" "^10.0.2"
@@ -1057,14 +1057,14 @@
     sinon "^15.1.0"
     ts-node "^10.9.1"
 
-"@eclipse-glsp/config@2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp/config/-/config-2.2.0.tgz#a55d7bd482e749e036ea4806aa3b6c3bf34a6225"
-  integrity sha512-tEPoYKxlL/8gSoS4B16H51JqzHGhdvDGvhOvu/iefwcuOGM7ZVSR4YzJjSFZjDQfsMPXtKXKFZqT2lizD283iA==
+"@eclipse-glsp/config@2.2.0-next.c32aadb.160+c32aadb":
+  version "2.2.0-next.c32aadb.160"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp/config/-/config-2.2.0-next.c32aadb.160.tgz#5e0c25ef98f2aad44de9cb3de1cb8c2523543835"
+  integrity sha512-rFpykLbc3VC+Nx9iR5dOQUGU9FXYOrxC8qnOOBt+ou+xkSvdDTUYHKC4QKmXRZbiVnhfpbj7CIauBoU2XxineA==
   dependencies:
-    "@eclipse-glsp/eslint-config" "2.2.0"
-    "@eclipse-glsp/prettier-config" "2.2.0"
-    "@eclipse-glsp/ts-config" "2.2.0"
+    "@eclipse-glsp/eslint-config" "2.2.0-next.c32aadb.160+c32aadb"
+    "@eclipse-glsp/prettier-config" "2.2.0-next.c32aadb.160+c32aadb"
+    "@eclipse-glsp/ts-config" "2.2.0-next.c32aadb.160+c32aadb"
     "@typescript-eslint/eslint-plugin" "^6.7.5"
     "@typescript-eslint/parser" "^6.7.5"
     eslint "^8.51.0"
@@ -1078,91 +1078,100 @@
     reflect-metadata "^0.1.13"
     rimraf "^5.0.5"
 
-"@eclipse-glsp/dev@2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp/dev/-/dev-2.2.0.tgz#cf745fe50c58a2036da07c92880f23a2336cdc7c"
-  integrity sha512-xXDHdS15ADqvc9iWoPlM78qNUKrVUyMAeiBOZHKcbMWNdqx6kg8w3oUNAmm2C896T8KHrdSLP5meGS2KChjY+g==
+"@eclipse-glsp/dev@next":
+  version "2.2.0-next.c32aadb.160"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp/dev/-/dev-2.2.0-next.c32aadb.160.tgz#d67cdceed91cb779e9495d06b6b4c7106541bc4f"
+  integrity sha512-ns0jJBxcW3qkzx8RV8JB/YYHOrK/9OXy7qrvhNabqAPRTpzn5ovp2kv7rZd97JGMPenq+2iSgbcY39eqq4zAHg==
   dependencies:
-    "@eclipse-glsp/cli" "2.2.0"
-    "@eclipse-glsp/config" "2.2.0"
-    "@eclipse-glsp/config-test" "2.2.0"
+    "@eclipse-glsp/cli" "2.2.0-next.c32aadb.160+c32aadb"
+    "@eclipse-glsp/config" "2.2.0-next.c32aadb.160+c32aadb"
+    "@eclipse-glsp/config-test" "2.2.0-next.c32aadb.160+c32aadb"
 
-"@eclipse-glsp/eslint-config@2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp/eslint-config/-/eslint-config-2.2.0.tgz#c98deff84bf2b7c368fd1d1ed6d232037fc1cf06"
-  integrity sha512-3zbBM3su+iKLwxHoTML6N3/y3MxRtQmDgxyNu4sR9LbBLZshiqd4kUeLFCAzFSznwe+5btbRabClv8pR33FTNQ==
+"@eclipse-glsp/eslint-config@2.2.0-next.c32aadb.160+c32aadb":
+  version "2.2.0-next.c32aadb.160"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp/eslint-config/-/eslint-config-2.2.0-next.c32aadb.160.tgz#40a2f916d662b5bd5eefac469214b2e74ba8d28c"
+  integrity sha512-BDYLSB9lkgGmwA2fPB8OjnZTD4r48AHWAYSwkFdy/1RwJxL/F8fWlfWu6c8o5AVuNyMkrqedtmfdehSZA01u7A==
 
-"@eclipse-glsp/graph@2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp/graph/-/graph-2.2.0.tgz#60dd92baa4b06bff19bdc14554400b920d89dabc"
-  integrity sha512-rPWss4USnUnLvMtF9IbrzavSYoKOriD2iyA03c5sfGDZt5aOk7zWk1iFVXGY97Cf6npw9lA+paW/QgSP2l2GMw==
+"@eclipse-glsp/graph@2.2.0-next.94+d7e90ed":
+  version "2.2.0-next.94"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp/graph/-/graph-2.2.0-next.94.tgz#33a6c8e007f2a605c9ca51be0b465ab54a8c24d4"
+  integrity sha512-O/mvworCZeM6wzT3TG3gwQkLahtKZ/IX8ULA5McUh3DdVlHITVgr/o3xbuE6MOb90owx/2kEd19ZabJCkDUBYg==
   dependencies:
-    "@eclipse-glsp/protocol" "2.2.0"
+    "@eclipse-glsp/protocol" next
 
-"@eclipse-glsp/layout-elk@2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp/layout-elk/-/layout-elk-2.2.0.tgz#dbd37a9e79e7301781c777968a9f4194abd6ce13"
-  integrity sha512-vvtY4+ETy0bEoqLsu1ME2XJhWDpIffLYUDcka6FOdI2oIyAqi8DJbMy0RUnZjKbewCS8/dqA9l9qrpzRgTIFGQ==
+"@eclipse-glsp/layout-elk@2.2.0-next.94+d7e90ed":
+  version "2.2.0-next.94"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp/layout-elk/-/layout-elk-2.2.0-next.94.tgz#ef288f004180a23c2a46f89192302897edb58f0c"
+  integrity sha512-kVygvWkKfrNJqZGiHR4YhHxQ+bPkRpOttgspkotJg22aQMo+0A7UTMtiDoTtynXpg1Bj7i+dygWgCM8woC9t9w==
   dependencies:
-    "@eclipse-glsp/server" "2.2.0"
+    "@eclipse-glsp/server" "2.2.0-next.94+d7e90ed"
     elkjs "^0.7.1"
 
-"@eclipse-glsp/mocha-config@2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp/mocha-config/-/mocha-config-2.2.0.tgz#77ab2664ea978db3400c0669ab5114417c1814e0"
-  integrity sha512-Vr9wEuYsTdV7ES0+G43yzSdZzpWn738W8LjSPySjpnrTHVABAB7b3Ba9ITd74Y/pdQXsL+6R47dEV1yoSIu/9A==
+"@eclipse-glsp/mocha-config@2.2.0-next.c32aadb.160+c32aadb":
+  version "2.2.0-next.c32aadb.160"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp/mocha-config/-/mocha-config-2.2.0-next.c32aadb.160.tgz#c440d499ced653d342dcb39c52944e03b879ec40"
+  integrity sha512-n3T212zAl5oKMGQM1V8L/GvDsZwyIDdZAVh25yHjh0hFgVfraaGqzvGPTZxlKmJBuD0++6LH9FDhUNcNhMllHQ==
 
-"@eclipse-glsp/nyc-config@2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp/nyc-config/-/nyc-config-2.2.0.tgz#3f62f6a1c13931b88ebe916d29eda6b2d9c58895"
-  integrity sha512-msBjz00ytdrAigloUtrJBY1pHm2Ugkeqi3ccJrkgxM164YZ/9iQrKCV0iUy9SoydbYCVFF0EtA4aH1jHVIrsbg==
+"@eclipse-glsp/nyc-config@2.2.0-next.c32aadb.160+c32aadb":
+  version "2.2.0-next.c32aadb.160"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp/nyc-config/-/nyc-config-2.2.0-next.c32aadb.160.tgz#9f84da72015c90aa2beb1394e14643f353a16158"
+  integrity sha512-m00F5RLly63TNDe76pW2yk/BLGKWpoD+qvga7ZSVDf2KPpdjf2cBjw2ei816H+Avl1TI+ufauQO8NdRu5O5Vuw==
 
-"@eclipse-glsp/prettier-config@2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp/prettier-config/-/prettier-config-2.2.0.tgz#76c686ea5f829d54f9cccc4d73eb097efe721dba"
-  integrity sha512-5FozTM0xUe0E/k2bqz1D0lPj4waAQyttSMmKIpNH1GwG8eS6lveAtPOuxhCNCR4vNCmhCDtazy+lCGmaKmlJcA==
+"@eclipse-glsp/prettier-config@2.2.0-next.c32aadb.160+c32aadb":
+  version "2.2.0-next.c32aadb.160"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp/prettier-config/-/prettier-config-2.2.0-next.c32aadb.160.tgz#c4e019dbbafd04483cc7916f25c8b3a151f7d916"
+  integrity sha512-xqfSe+UMS4p5WGimZnX5iIm1AX+x1CAAippobgogGRnbA5RBsUdOh/odFgfRcme6/IfyFWj5m4IY7IHlFPZwCw==
   dependencies:
     prettier-plugin-packagejson "~2.4.6"
 
-"@eclipse-glsp/protocol@2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp/protocol/-/protocol-2.2.0.tgz#a34d867e28b7f0708fa1d9ec349f650f0e1d427d"
-  integrity sha512-StoA5KqIgvknHkTYKj3+fQjRnuDzp0uhpkH6GOLvHteae0lekXeBYFLfA1pmyIMKycvCOq3k8+wG6tYJR8Q+Uw==
+"@eclipse-glsp/protocol@2.2.0-next.353+1e0d319":
+  version "2.2.0-next.353"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp/protocol/-/protocol-2.2.0-next.353.tgz#5effcb22dd25ffae5a7264324c2752cf89754629"
+  integrity sha512-LARvLG1bEmmfR8e6wFoEyYwOfMiQMyHEi/2SD/c08BUIDjEAuxbUEQyx2g+d9btfHdVEZJXfwfvy5oIuLEuI1Q==
   dependencies:
     sprotty-protocol "1.2.0"
     uuid "~10.0.0"
     vscode-jsonrpc "8.2.0"
 
-"@eclipse-glsp/server@2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp/server/-/server-2.2.0.tgz#bcb4f8c79d1c20aeeba6a57b4238e53fa6c343f0"
-  integrity sha512-NBls+FZ2WXlcRNgsofGmL0P3sGMpwdXpSmEbJigMHiw4wP2y9PjZqf6bdqBCaRn/COPk3YwaEUpyDUjurKeNWQ==
+"@eclipse-glsp/protocol@next":
+  version "2.2.0-next.330"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp/protocol/-/protocol-2.2.0-next.330.tgz#565b3fb4108dc2ff02e59c7ccddcb19f6f7539ef"
+  integrity sha512-IXMQgG1vTgWw3+0gfGSqvg9a9BwJu2I9qRXRxZ4PiolV4/xRKbJGGCyp/3HXasoEBW/vunz0nPk0Ji2DEee01w==
   dependencies:
-    "@eclipse-glsp/graph" "2.2.0"
-    "@eclipse-glsp/protocol" "2.2.0"
+    sprotty-protocol "1.0.0"
+    uuid "7.0.3"
+    vscode-jsonrpc "^8.0.2"
+
+"@eclipse-glsp/server@2.2.0-next.94+d7e90ed":
+  version "2.2.0-next.94"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp/server/-/server-2.2.0-next.94.tgz#b2c74cbaa06544278eb1c4c42c090120ed04c048"
+  integrity sha512-yPm09njBeltEou+ASW2aDlEgh3n7ae8LLW8R8q6JEUC3P8s1JR30mI5aJp0REEwsB2eJYdTn3upDk2CitHN8hA==
+  dependencies:
+    "@eclipse-glsp/graph" "2.2.0-next.94+d7e90ed"
+    "@eclipse-glsp/protocol" next
     "@types/uuid" "8.3.1"
     commander "^8.3.0"
     fast-json-patch "^3.1.0"
-    vscode-jsonrpc "8.2.0"
+    vscode-jsonrpc "^8.0.2"
     winston "^3.3.3"
     ws "^8.12.1"
 
-"@eclipse-glsp/sprotty@2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp/sprotty/-/sprotty-2.2.0.tgz#d16c1aa4b20b886a9d9381e1bf10d322c7fcee75"
-  integrity sha512-QGq0CRTmHsLgL5yUYZZitR00KuDifLOjixUE/MXAYxh7q8zcVl4wzmTIaE86EPeLcVzSLbdGmhwB5y7Q62a83g==
+"@eclipse-glsp/sprotty@2.2.0-next.353+1e0d319":
+  version "2.2.0-next.353"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp/sprotty/-/sprotty-2.2.0-next.353.tgz#7eaa4c0c89a4ae74cd79d1e6d45c6a6c8e8acc5e"
+  integrity sha512-WG/t1ZBPCqUk1y8gCMu7hITwi+Jsec5y46yedv5VfLxmGbgsF7eIEwd6hzMv1NYa4FsWYpQMS2m8+NU7RcNvRg==
   dependencies:
-    "@eclipse-glsp/protocol" "2.2.0"
+    "@eclipse-glsp/protocol" "2.2.0-next.353+1e0d319"
     autocompleter "^9.1.0"
     snabbdom "~3.5.1"
     sprotty "1.2.0"
     sprotty-protocol "1.2.0"
     vscode-jsonrpc "8.2.0"
 
-"@eclipse-glsp/ts-config@2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp/ts-config/-/ts-config-2.2.0.tgz#f08b683e9cc265280cd037965e35824b9a2df709"
-  integrity sha512-U2eD3kdKICK7OQXObLeMsrd80o+eHSIjss0HiUZjF7NQxsrNX9p04rJjEpO4HPrInUQPmpxsw3HVwk3mgo1mew==
+"@eclipse-glsp/ts-config@2.2.0-next.c32aadb.160+c32aadb":
+  version "2.2.0-next.c32aadb.160"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp/ts-config/-/ts-config-2.2.0-next.c32aadb.160.tgz#d660cd736056a91c0c79fb2076835073ad12d7b9"
+  integrity sha512-05D85X5tUY/M23rTDs1b9MfF+YbV7j97rTFss5PHad7YI2DOByqMGRxaoPI+xzyoQUUAHTxKekGb5KbE8douDQ==
 
 "@electron/get@^2.0.0":
   version "2.0.3"
@@ -6873,7 +6882,7 @@ interpret@^2.2.0:
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-2.2.0.tgz#1a78a0b5965c40a5416d007ad6f50ad27c417df9"
   integrity sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==
 
-inversify@^6.0.1, inversify@^6.0.2, inversify@~6.0.2:
+inversify@^6.0.1, inversify@~6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/inversify/-/inversify-6.0.2.tgz#dc7fa0348213d789d35ffb719dea9685570989c7"
   integrity sha512-i9m8j/7YIv4mDuYXUAcrpKPSaju/CIly9AHK5jvCBeoiM/2KEsuCQTTP+rzSWWpLYWRukdXFSl6ZTk2/uumbiA==
@@ -10767,6 +10776,11 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==
 
+sprotty-protocol@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/sprotty-protocol/-/sprotty-protocol-1.0.0.tgz#b22e2da7e10b168debdc17feb61c4b832f01f614"
+  integrity sha512-p1H+ihcOmj0LEk2atcwOnYQPm0WByaOB1yX7fd869ONfQ5R+7x0X20YPdVLeCWmnhsszC/Rf91ojwaQiNIiHNA==
+
 sprotty-protocol@1.2.0, sprotty-protocol@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/sprotty-protocol/-/sprotty-protocol-1.2.0.tgz#cfd6d637f2670a3d641997bb5add27cb1bddb57a"
@@ -11689,15 +11703,15 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==
 
+uuid@7.0.3, uuid@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-7.0.3.tgz#c5c9f2c8cf25dc0a372c4df1441c41f5bd0c680b"
+  integrity sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==
+
 uuid@^3.0.1, uuid@^3.3.2:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
-
-uuid@^7.0.3:
-  version "7.0.3"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-7.0.3.tgz#c5c9f2c8cf25dc0a372c4df1441c41f5bd0c680b"
-  integrity sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==
 
 uuid@^8.3.2:
   version "8.3.2"
@@ -11773,7 +11787,7 @@ vary@^1, vary@~1.1.2:
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==
 
-vscode-jsonrpc@8.2.0:
+vscode-jsonrpc@8.2.0, vscode-jsonrpc@^8.0.2:
   version "8.2.0"
   resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz#f43dfa35fb51e763d17cd94dcca0c9458f35abf9"
   integrity sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==
@@ -12128,11 +12142,6 @@ ws@8.11.0, ws@~8.11.0:
   version "8.11.0"
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.11.0.tgz#6a0d36b8edfd9f96d8b25683db2f8d7de6e8e143"
   integrity sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==
-
-ws@^8.11.0:
-  version "8.18.0"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.0.tgz#0d7505a6eafe2b0e712d232b42279f53bc289bbc"
-  integrity sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==
 
 ws@^8.12.1, ws@^8.14.1:
   version "8.17.0"


### PR DESCRIPTION
Reverts eclipse-glsp/glsp-theia-integration#221
Due to a bug discovered during the release process its necessary to revert the currently ongoing 2.2.0 release.
Already published artifacts will be removed/ unpublished
and a clean 2.2.1 release will be published