### PR TITLE
GLSP-1362: Register `GLSPDiagramManager`s as open with handler

### DIFF
--- a/.github/workflows/theia-compat.yml
+++ b/.github/workflows/theia-compat.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        theia_version: [1.45.1, 1.49.1, latest]
+        theia_version: [1.49.1, latest]
     steps:
       - uses: actions/checkout@v4.1.7
       - uses: actions/setup-node@v4.0.2

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ For details on building the project, please see the [README file of the theia-in
 | 1.0.0-theia1.34.0               | >=1.34.0 < 1.39.0  |
 | 2.0.0                           | >=1.39.0 < 1.45.0  |
 | 2.1.x                           | >=1.39.0 < 1.45.0  |
-| 2.1.0-theia1.45.0               | >=1.45.0 < 1.50.0  |
-| 2.1.0-theia1.50.0               | >=1.50.0           |
-| next                            | >=1.50.0           |
+| 2.1.0-theia1.45.0               | >=1.45.0 < 1.49.0  |
+| 2.1.0-theia1.49.0               | >=1.49.0           |
+| next                            | >=1.49.0           |
 
 > Note: For versions <=1.0.0 it is not possible to safely restrict the maximum version of Theia packages. If you encounter build errors related to multiple resolved Theia versions please add a resolutions block to the `package.json` of your project e.g. for `1.0.0-theia1.27.0`:
 

--- a/examples/workflow-theia/src/common/workflow-language.ts
+++ b/examples/workflow-theia/src/common/workflow-language.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2019-2021 EclipseSource and others.
+ * Copyright (c) 2019-2024 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -17,7 +17,8 @@ import { GLSPDiagramLanguage } from '@eclipse-glsp/theia-integration/lib/common'
 
 export const WorkflowLanguage: GLSPDiagramLanguage = {
     contributionId: 'workflow',
-    label: 'Workflow Diagram',
+    label: 'Workflow Editor',
+    providerName: 'GLSP Diagram',
     diagramType: 'workflow-diagram',
     fileExtensions: ['.wf'],
     iconClass: 'codicon codicon-type-hierarchy-sub'

--- a/packages/theia-integration/src/browser/diagram/glsp-diagram-manager.ts
+++ b/packages/theia-integration/src/browser/diagram/glsp-diagram-manager.ts
@@ -21,12 +21,14 @@ import {
     ApplicationShell,
     FrontendApplicationContribution,
     OpenHandler,
+    OpenWithHandler,
+    OpenWithService,
     WidgetFactory,
     WidgetOpenerOptions,
     WidgetOpenHandler
 } from '@theia/core/lib/browser';
 import URI from '@theia/core/lib/common/uri';
-import { inject, injectable, interfaces } from '@theia/core/shared/inversify';
+import { inject, injectable, interfaces, postConstruct } from '@theia/core/shared/inversify';
 import { EditorManager } from '@theia/editor/lib/browser';
 import { DiagramServiceProvider } from '../diagram-service-provider';
 import { TheiaOpenerOptionsNavigationService } from '../theia-opener-options-navigation-service';
@@ -48,7 +50,7 @@ export function registerDiagramManager(
 }
 
 @injectable()
-export abstract class GLSPDiagramManager extends WidgetOpenHandler<GLSPDiagramWidget> implements WidgetFactory {
+export abstract class GLSPDiagramManager extends WidgetOpenHandler<GLSPDiagramWidget> implements WidgetFactory, OpenWithHandler {
     @inject(TheiaOpenerOptionsNavigationService)
     protected readonly diagramNavigationService: TheiaOpenerOptionsNavigationService;
 
@@ -61,6 +63,9 @@ export abstract class GLSPDiagramManager extends WidgetOpenHandler<GLSPDiagramWi
     @inject(EditorManager)
     protected readonly editorManager: EditorManager;
 
+    @inject(OpenWithService)
+    protected openWithService: OpenWithService;
+
     abstract get fileExtensions(): string[];
 
     abstract get diagramType(): string;
@@ -68,6 +73,16 @@ export abstract class GLSPDiagramManager extends WidgetOpenHandler<GLSPDiagramWi
     abstract get contributionId(): string;
 
     protected widgetCount = 0;
+
+    protected registerOpenWithHandler = true;
+
+    @postConstruct()
+    protected override init(): void {
+        super.init();
+        if (this.registerOpenWithHandler) {
+            this.openWithService.registerHandler(this);
+        }
+    }
 
     override async doOpen(widget: GLSPDiagramWidget, maybeOptions?: WidgetOpenerOptions): Promise<void> {
         const options: WidgetOpenerOptions = {
@@ -169,6 +184,10 @@ export abstract class GLSPDiagramManager extends WidgetOpenHandler<GLSPDiagramWi
 
     get iconClass(): string {
         return codiconCSSString('type-hierarchy-sub');
+    }
+
+    get providerName(): string | undefined {
+        return undefined;
     }
 }
 

--- a/packages/theia-integration/src/browser/glsp-theia-container-module.ts
+++ b/packages/theia-integration/src/browser/glsp-theia-container-module.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2021-2023 EclipseSource and others.
+ * Copyright (c) 2021-2024 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -213,6 +213,7 @@ class ConfigurableGLSPDiagramManager extends GLSPDiagramManager {
     private _fileExtensions: string[] = [];
     private _iconClass = codiconCSSString('type-hierarchy-sub');
     private _contributionId: string;
+    private _providerName?: string;
 
     public doConfigure(diagramLanguage: GLSPDiagramLanguage): void {
         this._fileExtensions = diagramLanguage.fileExtensions;
@@ -220,6 +221,7 @@ class ConfigurableGLSPDiagramManager extends GLSPDiagramManager {
         this._label = diagramLanguage.label;
         this._iconClass = diagramLanguage.iconClass || this._iconClass;
         this._contributionId = diagramLanguage.contributionId;
+        this._providerName = diagramLanguage.providerName;
     }
 
     get fileExtensions(): string[] {
@@ -239,6 +241,10 @@ class ConfigurableGLSPDiagramManager extends GLSPDiagramManager {
 
     get contributionId(): string {
         return this._contributionId;
+    }
+
+    override get providerName(): string | undefined {
+        return this._providerName;
     }
 
     override get iconClass(): string {

--- a/packages/theia-integration/src/common/glsp-diagram-language.ts
+++ b/packages/theia-integration/src/common/glsp-diagram-language.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2021 EclipseSource and others.
+ * Copyright (c) 2021-2024 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -27,9 +27,15 @@ export interface GLSPDiagramLanguage {
     readonly fileExtensions: string[];
     /** Display-label for this language. Is used in UI elements like the editor-widget title */
     readonly label: string;
+    /**
+     * An optional provider name for this language. If defined, it will be used in supporting UI elements
+     *  e.g. the open-with dialog.
+     */
+    readonly providerName?: string;
     /** The icon class that is associated with this language. If undefined, a default icon class will be used  */
     readonly iconClass?: string;
-    /** The id of the diagram manager that is responsible for this language. If undefined, a default id derived
+    /**
+     * The id of the diagram manager that is responsible for this language. If undefined, a default id derived
      * from the diagram type will be used.
      */
     readonly diagramManagerId?: string;


### PR DESCRIPTION
Fixes https://github.com/eclipse-glsp/glsp/issues/1362

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-glsp/glsp/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See [SECURITY.md](https://github.com/eclipse-glsp/glsp/blob/master/SECURITY.md),
to learn how to report vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Changelog

<!-- Please check, when if it applies to your change. -->

-   [x] This PR should be mentioned in the changelog
-   [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)
