### PR TITLE
GLSP-1485: Dispose progress reporters on close

### DIFF
--- a/packages/theia-integration/src/browser/diagram/features/notification/theia-glsp-message-service.ts
+++ b/packages/theia-integration/src/browser/diagram/features/notification/theia-glsp-message-service.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2023 EclipseSource and others.
+ * Copyright (c) 2023-2025 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,6 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 import {
+    Disposable,
     EndProgressAction,
     IActionHandler,
     ICommand,
@@ -23,17 +24,23 @@ import {
 } from '@eclipse-glsp/client';
 import { MessageService, Progress } from '@theia/core';
 import { ConfirmDialog } from '@theia/core/lib/browser';
-import { inject, injectable } from '@theia/core/shared/inversify';
+import { inject, injectable, preDestroy } from '@theia/core/shared/inversify';
 import { Action } from 'sprotty-protocol/lib/actions';
 
 @injectable()
-export class TheiaGLSPMessageService implements IActionHandler {
+export class TheiaGLSPMessageService implements IActionHandler, Disposable {
     static readonly SHOW_DETAILS_LABEL = 'Show details';
 
     @inject(MessageService)
     protected messageService: MessageService;
 
     protected progressReporters: Map<string, Progress> = new Map();
+
+    @preDestroy()
+    dispose(): void {
+        this.progressReporters.forEach(progress => progress.cancel());
+        this.progressReporters.clear();
+    }
 
     handle(action: Action): void | Action | ICommand {
         if (MessageAction.is(action)) {


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-glsp/glsp/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See [SECURITY.md](https://github.com/eclipse-glsp/glsp/blob/master/SECURITY.md),
to learn how to report vulnerabilities.
-->

#### What it does
Ensure that pending progress reporters are properly disposed when the diagram is closed

Part of: https://github.com/eclipse-glsp/glsp/issues/1485
<!-- Include relevant issues and describe how they are addressed. -->

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Changelog

<!-- Please check, when if it applies to your change. -->

-   [x] This PR should be mentioned in the changelog
-   [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)
