### PR TITLE
GLSP-1392: Enforce focus restore after context menu close

### DIFF
--- a/packages/theia-integration/src/browser/theia-glsp-context-menu-service.ts
+++ b/packages/theia-integration/src/browser/theia-glsp-context-menu-service.ts
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 // based on: https://github.com/eclipse-sprotty/sprotty-theia/blob/v0.12.0/src/sprotty/theia-sprotty-context-menu-service.ts
-import { Anchor, IActionDispatcher, IContextMenuService, MenuItem } from '@eclipse-glsp/client';
+import { Anchor, FocusStateChangedAction, IActionDispatcher, IContextMenuService, MenuItem } from '@eclipse-glsp/client';
 import { Command, CommandHandler, CommandRegistry, Disposable, MenuAction, MenuModelRegistry, MenuPath } from '@theia/core';
 import { ApplicationShell, ContextMenuRenderer } from '@theia/core/lib/browser';
 import { inject, injectable } from 'inversify';
@@ -69,6 +69,7 @@ export class TheiaContextMenuService implements IContextMenuService {
                     onHide();
                 }
                 this.scheduleCleanup();
+                this.restoreFocus();
             }
         };
         this.contextMenuRenderer.render(renderOptions);
@@ -120,6 +121,14 @@ export class TheiaContextMenuService implements IContextMenuService {
     protected cleanUp(): void {
         this.disposables.forEach(disposable => disposable.dispose(this.menuProvider, this.commandRegistry));
         this.disposables = [];
+    }
+
+    protected restoreFocus(): void {
+        const widget = this.diagramWidget;
+        if (!widget || widget.hasFocus) {
+            return;
+        }
+        widget.actionDispatcher.dispatch(FocusStateChangedAction.create(true));
     }
 }
 


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-glsp/glsp/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See [SECURITY.md](https://github.com/eclipse-glsp/glsp/blob/master/SECURITY.md),
to learn how to report vulnerabilities.
-->

#### What it does
Ensure that we restore the focus (in diagram FocusTracker) after a GLSP context menu was closed.
Currently we relied on direct activation (i.e. the widget indirectly received focus again after a (browser) context menu was closed) This does not work with native menu elements (electron). By restoring the focus activly on close we make sure that this works consistent for all implementations.

Fixes https://github.com/eclipse-glsp/glsp/issues/1392
<!-- Include relevant issues and describe how they are addressed. -->

#### How to test
-Build the electron & start the electron  app (yarn && yarn electron build).
-Play around with the context menu and make sure that the diagram is in focus again after its closed.

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Changelog

<!-- Please check, when if it applies to your change. -->

- [x] This PR should be mentioned in the changelog
- [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)
