### PR TITLE
Add paths-ignore to CI and E2E workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,16 @@ on:
   workflow_dispatch:
   push:
     branches: [master]
+    paths-ignore:
+      - '**/*.md'
+      - 'LICENSE'
+      - '.vscode/**'
   pull_request:
     branches: [master]
+    paths-ignore:
+      - '**/*.md'
+      - 'LICENSE'
+      - '.vscode/**'
 
 jobs:
   build:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,8 +7,16 @@ on:
   workflow_dispatch:
   push:
     branches: [master]
+    paths-ignore:
+      - '**/*.md'
+      - 'LICENSE'
+      - '.vscode/**'
   pull_request:
     branches: [master]
+    paths-ignore:
+      - '**/*.md'
+      - 'LICENSE'
+      - '.vscode/**'
 
 jobs:
   playwright:
@@ -16,24 +24,24 @@ jobs:
     timeout-minutes: 120
     runs-on: ubuntu-22.04
     env:
-      STANDALONE_URL: 'file://${{ github.workspace }}/glsp-client/examples/workflow-standalone/app/diagram.html'
+      GLSP_REPO_DIR: '${{ github.workspace }}'
       GLSP_SERVER_PORT: '8081'
-      GLSP_SERVER_PLAYWRIGHT_MANAGED: 'false'
       GLSP_WEBSOCKET_PATH: 'workflow'
-      THEIA_URL: 'http://localhost:3000'
-      VSCODE_VSIX_ID: 'eclipse-glsp.workflow-vscode-example'
-      VSCODE_VSIX_PATH: '${{ github.workspace }}/.../vscode-example-2.3.0-next.vsix'
       GLSP_SERVER_DEBUG: 'true'
       GLSP_SERVER_TYPE: 'node'
 
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
-          path: 'theia-integration'
+          path: 'glsp-theia-integration'
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: 'eclipse-glsp/glsp-playwright'
           path: 'glsp-playwright'
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          repository: 'eclipse-glsp/glsp-server-node'
+          path: 'glsp-server-node'
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: '22'
@@ -42,7 +50,7 @@ jobs:
           python-version: '3.11'
       - name: Build Theia Integration
         run: |
-          cd theia-integration
+          cd glsp-theia-integration
           yarn --skip-integrity-check --network-timeout 100000
           yarn browser build
         env:
@@ -51,15 +59,15 @@ jobs:
         run: |
           cd glsp-playwright
           yarn
-      - name: Start Browser App
+      - name: Build GLSP Server Node
         run: |
-          cd theia-integration
-          yarn browser start &
+          cd glsp-server-node
+          yarn
       - name: Run Playwright tests
         id: run_playwright_tests
         run: |
           cd glsp-playwright
-           yarn test:theia
+          yarn test:theia
       - name: Upload Playwright report
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()

--- a/.github/workflows/theia-compat.yml
+++ b/.github/workflows/theia-compat.yml
@@ -4,6 +4,10 @@ on:
   workflow_dispatch:
   push:
     branches: [master]
+    paths-ignore:
+      - '**/*.md'
+      - 'LICENSE'
+      - '.vscode/**'
   schedule:
     - cron: '0 8 * * 1' # Every Monday at 8 AM UTC
 
@@ -15,23 +19,23 @@ jobs:
       matrix:
         theia_version: [1.66.0, 1.68.0, latest]
     env:
-      STANDALONE_URL: none'
+      GLSP_REPO_DIR: '${{ github.workspace }}'
       GLSP_SERVER_PORT: '8081'
-      GLSP_SERVER_PLAYWRIGHT_MANAGED: 'false'
       GLSP_WEBSOCKET_PATH: 'workflow'
-      THEIA_URL: 'http://localhost:3000'
-      VSCODE_VSIX_ID: 'none'
-      VSCODE_VSIX_PATH: 'none'
       GLSP_SERVER_DEBUG: 'true'
       GLSP_SERVER_TYPE: 'node'
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
-          path: 'theia-integration'
+          path: 'glsp-theia-integration'
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: 'eclipse-glsp/glsp-playwright'
           path: 'glsp-playwright'
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          repository: 'eclipse-glsp/glsp-server-node'
+          path: 'glsp-server-node'
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 22.x
@@ -40,27 +44,27 @@ jobs:
           python-version: '3.11'
       - name: Build
         run: |
-          cd theia-integration
+          cd glsp-theia-integration
           yarn --skip-integrity-check --network-timeout 100000
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # https://github.com/microsoft/vscode-ripgrep/issues/9
       - name: Change theia version
         run: |
-          cd theia-integration
+          cd glsp-theia-integration
           yarn change:theia-version ${{ matrix.theia_version }}
       - name: Clean yarn.lock
         run: |
-          cd theia-integration
+          cd glsp-theia-integration
           rm -f yarn.lock
       - name: Build electron
         run: |
-          cd theia-integration
+          cd glsp-theia-integration
           yarn electron build
         env:
           NODE_OPTIONS: --max_old_space_size=4096
       - name: Build browser
         run: |
-          cd theia-integration
+          cd glsp-theia-integration
           yarn --skip-integrity-check --network-timeout 100000 && yarn browser build
         env:
           NODE_OPTIONS: --max_old_space_size=4096
@@ -69,15 +73,15 @@ jobs:
         run: |
           cd glsp-playwright
           yarn
-      - name: Start Browser App
+      - name: Build GLSP Server Node
         run: |
-          cd theia-integration
-          yarn browser start &
+          cd glsp-server-node
+          yarn
       - name: Run Playwright tests
         id: run_playwright_tests
         run: |
           cd glsp-playwright
-            yarn test:theia
+          yarn test:theia
       - name: Upload Playwright report
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()


### PR DESCRIPTION
## Summary
- Add `paths-ignore` to `push` and `pull_request` triggers in CI and E2E workflows
- Skips workflow runs for changes to markdown files (`**/*.md`), `LICENSE`, and `.vscode/**`
- Updates E2E workflow configuration (env vars, server node checkout, test runner setup)

## Test plan
- [ ] Verify CI workflow is not triggered by markdown-only changes
- [ ] Verify E2E workflow is not triggered by markdown-only changes
- [ ] Verify both workflows still trigger for code changes