### PR TITLE
Fix Theia compatibility build for old Theia versions

### DIFF
--- a/.github/workflows/theia-compat.yml
+++ b/.github/workflows/theia-compat.yml
@@ -16,8 +16,9 @@ jobs:
     name: Build
     runs-on: ubuntu-22.04
     strategy:
+      fail-fast: false
       matrix:
-        theia_version: [1.66.0, 1.68.0, latest]
+        theia_version: [1.66.0, 1.71.2, latest]
     env:
       GLSP_REPO_DIR: '${{ github.workspace }}'
       GLSP_SERVER_PORT: '8081'
@@ -52,10 +53,14 @@ jobs:
         run: |
           cd glsp-theia-integration
           yarn change:theia-version ${{ matrix.theia_version }}
-      - name: Clean yarn.lock
+      # Reinstall to apply the downgrade. Must run before `electron build` so theia's native
+      # module backup/restore (.browser_modules) operates on the correctly downgraded tree.
+      - name: Install downgraded dependencies
         run: |
           cd glsp-theia-integration
-          rm -f yarn.lock
+          yarn install --force --skip-integrity-check --network-timeout 100000
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # https://github.com/microsoft/vscode-ripgrep/issues/9
       - name: Build electron
         run: |
           cd glsp-theia-integration


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-glsp/glsp/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See [SECURITY.md](https://github.com/eclipse-glsp/glsp/blob/master/SECURITY.md),
to learn how to report vulnerabilities.
-->

#### What it does
The compat matrix failed for Theia < 1.70 (e.g. 1.66.0): the Theia backend
crashed on boot with "Failed to load native module: pty.node" because node-pty's binary was never bundled into the browser app.
<!-- Include relevant issues and describe how they are addressed. -->

#### How to test
- Verification after merge (compat build only runs on master pushes)
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Changelog

<!-- Please check, when if it applies to your change. -->

- [ ] This PR should be mentioned in the changelog
- [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)
