### PR TITLE
GLSP-1636: Fix Theia compat build for old Theia versions

### DIFF
--- a/.github/workflows/theia-compat.yml
+++ b/.github/workflows/theia-compat.yml
@@ -63,7 +63,10 @@ jobs:
       - name: Install downgraded dependencies
         run: |
           cd glsp-theia-integration
-          pnpm install --no-frozen-lockfile
+          # Old Theia (1.66.0) pulls @electron/rebuild -> @electron/node-gyp resolved via git, which
+          # pnpm's default blockExoticSubdeps rejects. Relax it for the (never-published) compat build
+          # only; the main build keeps the guard.
+          pnpm install --no-frozen-lockfile --config.blockExoticSubdeps=false
           pnpm compile
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # https://github.com/microsoft/vscode-ripgrep/issues/9
@@ -76,7 +79,8 @@ jobs:
       - name: Build browser
         run: |
           cd glsp-theia-integration
-          pnpm install --no-frozen-lockfile
+          # See "Install downgraded dependencies": old Theia needs the exotic-subdep guard relaxed.
+          pnpm install --no-frozen-lockfile --config.blockExoticSubdeps=false
           pnpm compile
           pnpm browser build
         env:

--- a/configs/change-theia-version.ts
+++ b/configs/change-theia-version.ts
@@ -25,6 +25,12 @@ const ELECTRON_APP_PATH = path.resolve(ROOT_PATH, 'examples', 'electron-app');
 const RIPGREP_RESOLUTION_VERSION = '1.17.1';
 const RIPGREP_MIN_THEIA_VERSION = '1.71.0';
 
+// pnpm 11 no longer reads the `pnpm.overrides` field from package.json — overrides must live in
+// pnpm-workspace.yaml. Manage the ripgrep pin as a clearly-delimited, removable block.
+const WORKSPACE_YAML_PATH = path.resolve(ROOT_PATH, 'pnpm-workspace.yaml');
+const RIPGREP_BLOCK_BEGIN = '# BEGIN compat ripgrep override (managed by change-theia-version.ts)';
+const RIPGREP_BLOCK_END = '# END compat ripgrep override';
+
 function updateTheiaDependencyVersion(appPath: string, version: string, electronVersion?: string): void {
     const pkgJson = path.join(appPath, 'package.json');
     const pkg: { dependencies: Record<string, string>; devDependencies: Record<string, string> } = JSON.parse(
@@ -52,36 +58,24 @@ function updateTheiaDependencyVersion(appPath: string, version: string, electron
 }
 
 function updateRipgrepResolution(version: string): void {
-    const pkgJson = path.join(ROOT_PATH, 'package.json');
-    const pkg: { pnpm?: { overrides?: Record<string, string> } } = JSON.parse(fs.readFileSync(pkgJson, 'utf8'));
-
     const minVersion = version === 'latest' ? undefined : (semver.minVersion(version) ?? undefined);
     const needsResolution = minVersion !== undefined && semver.lt(minVersion, RIPGREP_MIN_THEIA_VERSION);
 
-    const pnpm = pkg.pnpm ?? {};
-    const overrides = pnpm.overrides ?? {};
+    let content = fs.readFileSync(WORKSPACE_YAML_PATH, 'utf8');
+    // Strip any previously injected block first, so the operation is idempotent.
+    const blockRegex = new RegExp(`\\n*${RIPGREP_BLOCK_BEGIN}[\\s\\S]*?${RIPGREP_BLOCK_END}\\n*`);
+    content = content.replace(blockRegex, '\n').replace(/\s*$/, '\n');
+
     if (needsResolution) {
-        overrides['@vscode/ripgrep'] = RIPGREP_RESOLUTION_VERSION;
+        content +=
+            `\n${RIPGREP_BLOCK_BEGIN}\n` +
+            'overrides:\n' +
+            `    '@vscode/ripgrep': '${RIPGREP_RESOLUTION_VERSION}'\n` +
+            `${RIPGREP_BLOCK_END}\n`;
         console.log(`Pinned @vscode/ripgrep to ${RIPGREP_RESOLUTION_VERSION} for @theia version ${version}`);
-    } else {
-        delete overrides['@vscode/ripgrep'];
     }
 
-    if (Object.keys(overrides).length > 0) {
-        pnpm.overrides = overrides;
-        pkg.pnpm = pnpm;
-    } else {
-        if (pnpm.overrides !== undefined) {
-            delete pnpm.overrides;
-        }
-        if (Object.keys(pnpm).length === 0) {
-            delete pkg.pnpm;
-        } else {
-            pkg.pnpm = pnpm;
-        }
-    }
-
-    fs.writeFileSync(pkgJson, JSON.stringify(pkg, undefined, 2) + '\n');
+    fs.writeFileSync(WORKSPACE_YAML_PATH, content);
 }
 
 const version = process.argv[2];

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -32,6 +32,9 @@ allowBuilds:
     msgpackr-extract: true
     node-pty: true
     puppeteer: true
+    # Old Theia (< 1.71) compat builds pin @vscode/ripgrep to 1.17.1, whose postinstall downloads
+    # the `rg` binary that the Theia webpack build copies. Allow it so the build isn't blocked.
+    '@vscode/ripgrep': true
 
 # Min age (minutes) of dependency versions to install — supply-chain hardening. 4320 = 72h.
 minimumReleaseAge: 4320


### PR DESCRIPTION
The 1.66.0 compatibility build broke after the pnpm migration:

- pnpm 11's default `blockExoticSubdeps` rejected `@electron/node-gyp` (resolved via git, pulled by old Theia's `@electron/rebuild`). Relax the guard on the compat build's install steps only; the main (published) build keeps it.
- The `@vscode/ripgrep` pin for Theia < 1.71 was written to package.json `pnpm.overrides`, which pnpm 11 ignores. Write it to pnpm-workspace.yaml so the pin actually applies.
- Allow `@vscode/ripgrep`'s install script so its `rg` binary is downloaded (the Theia webpack build copies it); otherwise pnpm aborts with ERR_PNPM_IGNORED_BUILDS.

Part of: eclipse-glsp/glsp#1636

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-glsp/glsp/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See [SECURITY.md](https://github.com/eclipse-glsp/glsp/blob/master/SECURITY.md),
to learn how to report vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Changelog

<!-- Please check, when if it applies to your change. -->

- [ ] This PR should be mentioned in the changelog
- [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)
