### PR TITLE
GLSP-1636: Fix duplicate overrides key in Theia compat builds

### DIFF
--- a/configs/change-theia-version.ts
+++ b/configs/change-theia-version.ts
@@ -57,21 +57,31 @@ function updateTheiaDependencyVersion(appPath: string, version: string, electron
     console.log(`Updated ${appPath} to @theia version ${version}`);
 }
 
+function escapeForRegExp(value: string): string {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 function updateRipgrepResolution(version: string): void {
     const minVersion = version === 'latest' ? undefined : (semver.minVersion(version) ?? undefined);
     const needsResolution = minVersion !== undefined && semver.lt(minVersion, RIPGREP_MIN_THEIA_VERSION);
 
     let content = fs.readFileSync(WORKSPACE_YAML_PATH, 'utf8');
-    // Strip any previously injected block first, so the operation is idempotent.
-    const blockRegex = new RegExp(`\\n*${RIPGREP_BLOCK_BEGIN}[\\s\\S]*?${RIPGREP_BLOCK_END}\\n*`);
-    content = content.replace(blockRegex, '\n').replace(/\s*$/, '\n');
+    // Strip any previously injected block (with its indentation) first, so the operation is idempotent.
+    const blockRegex = new RegExp(`\\n*[ \\t]*${escapeForRegExp(RIPGREP_BLOCK_BEGIN)}[\\s\\S]*?${escapeForRegExp(RIPGREP_BLOCK_END)}`, 'g');
+    content = content.replace(blockRegex, '').replace(/\s*$/, '\n');
 
     if (needsResolution) {
-        content +=
-            `\n${RIPGREP_BLOCK_BEGIN}\n` +
-            'overrides:\n' +
-            `    '@vscode/ripgrep': '${RIPGREP_RESOLUTION_VERSION}'\n` +
-            `${RIPGREP_BLOCK_END}\n`;
+        const entry = `    '@vscode/ripgrep': '${RIPGREP_RESOLUTION_VERSION}'`;
+        // Merge into the existing top-level `overrides:` mapping if present; emitting a second
+        // `overrides:` key would be a duplicate YAML mapping key and break the install.
+        const overridesHeader = content.match(/^overrides:[ \t]*$/m);
+        if (overridesHeader) {
+            const insertAt = overridesHeader.index! + overridesHeader[0].length;
+            const block = `\n    ${RIPGREP_BLOCK_BEGIN}\n${entry}\n    ${RIPGREP_BLOCK_END}`;
+            content = content.slice(0, insertAt) + block + content.slice(insertAt);
+        } else {
+            content = `${content.replace(/\s*$/, '\n')}\n${RIPGREP_BLOCK_BEGIN}\noverrides:\n${entry}\n${RIPGREP_BLOCK_END}\n`;
+        }
         console.log(`Pinned @vscode/ripgrep to ${RIPGREP_RESOLUTION_VERSION} for @theia version ${version}`);
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-glsp/glsp/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See [SECURITY.md](https://github.com/eclipse-glsp/glsp/blob/master/SECURITY.md),
to learn how to report vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

Part of: eclipse-glsp/glsp#1636

The Theia compatibility build pins `@vscode/ripgrep` for old Theia versions by
injecting an `overrides:` block into `pnpm-workspace.yaml` via
`change-theia-version.ts`. Since #332 added a top-level `overrides:` key for the
security overrides, that injection produced a **second** `overrides:` mapping —
a duplicate YAML key — which broke the downgraded install for Theia `1.66.0`
(`duplicated mapping key`).

- Merge the ripgrep pin into the existing `overrides:` mapping instead of
  emitting a second `overrides:` key; fall back to creating the key only when
  none exists
- Strip the managed block accounting for its indentation so the operation stays
  idempotent, and escape the marker comments used in the regex

#### How to test



#### Changelog

<!-- Please check, when if it applies to your change. -->

- [ ] This PR should be mentioned in the changelog
- [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)
