### PR TITLE
GLSP-1728: Report diagram load failures in the widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changes
 
+- [diagram] Report a diagram that fails to load in the widget instead of failing silently [#340](https://github.com/eclipse-glsp/glsp-theia-integration/pull/340)
+
 ### Potentially Breaking Changes
 
 ## [v2.7.0 - 01/06/2026](https://github.com/eclipse-glsp/glsp-theia-integration/releases/tag/v2.7.0)

--- a/packages/theia-integration/css/diagram.css
+++ b/packages/theia-integration/css/diagram.css
@@ -171,3 +171,29 @@
     opacity: 0;
     pointer-events: none;
 }
+
+/* overlays the widget, so a sibling that claims the full height cannot push the message out of view */
+.glsp-diagram-load-error {
+    position: absolute;
+    inset: 0;
+    z-index: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: calc(var(--theia-ui-padding) * 3);
+    background: var(--theia-editor-background);
+    text-align: center;
+    user-select: text;
+}
+
+.glsp-diagram-load-error > h3 {
+    color: var(--theia-errorForeground);
+    margin: 0;
+}
+
+.glsp-diagram-load-error > p {
+    color: var(--theia-descriptionForeground);
+    max-width: 60ch;
+    overflow-wrap: break-word;
+}

--- a/packages/theia-integration/src/browser/diagram/glsp-diagram-widget.ts
+++ b/packages/theia-integration/src/browser/diagram/glsp-diagram-widget.ts
@@ -89,6 +89,7 @@ export class GLSPDiagramWidget extends BaseWidget implements SaveableSource, Sta
     readonly theiaSelectionService: SelectionService;
 
     protected diagramContainer?: HTMLDivElement;
+    protected loadErrorContainer?: HTMLDivElement;
     protected copyPasteHandler?: ICopyPasteHandler;
     protected requestModelOptions: Args;
     protected storeViewportStateOnClose = true;
@@ -117,7 +118,7 @@ export class GLSPDiagramWidget extends BaseWidget implements SaveableSource, Sta
         if (!this.diagramContainer) {
             // Create the container and initialize its content upon first attachment
             this.createContainer();
-            this.initializeDiagram();
+            this.initializeDiagram().catch(error => this.handleDiagramLoadError(error));
         }
         super.onAfterAttach(msg);
 
@@ -154,6 +155,50 @@ export class GLSPDiagramWidget extends BaseWidget implements SaveableSource, Sta
 
         const loader = this.diContainer.get(DiagramLoader);
         return loader.load({ requestModelOptions: this.requestModelOptions });
+    }
+
+    /**
+     * Reports a diagram that could not be loaded.
+     *
+     * @param error The reason the diagram could not be loaded.
+     */
+    protected handleDiagramLoadError(error: unknown): void {
+        console.error(`Could not load diagram '${this.options.uri}':`, error);
+        this.renderLoadError(error instanceof Error ? error.message : String(error));
+    }
+
+    /**
+     * Renders a message in place of the diagram.
+     *
+     * @param reason The reason to show to the user.
+     */
+    protected renderLoadError(reason: string): void {
+        this.hideDiagram();
+        this.loadErrorContainer?.remove();
+        this.loadErrorContainer = document.createElement('div');
+        this.loadErrorContainer.classList.add('glsp-diagram-load-error');
+
+        const message = document.createElement('h3');
+        message.textContent = 'Could not load diagram';
+        const detail = document.createElement('p');
+        // `textContent` rather than `innerHTML`, the reason may carry server-provided content
+        detail.textContent = reason;
+
+        this.loadErrorContainer.append(message, detail);
+        this.node.appendChild(this.loadErrorContainer);
+    }
+
+    /**
+     * Hides the diagram, if it is already rendered.
+     *
+     * The element is looked up rather than taken from {@link diagramContainer}, because the viewer replaces the
+     * element it renders into and leaves that field pointing at a detached node.
+     */
+    protected hideDiagram(): void {
+        const diagram = this.node.querySelector<HTMLElement>(`#${this.viewerOptions.baseDiv}`);
+        if (diagram) {
+            diagram.style.display = 'none';
+        }
     }
 
     protected getRequestModelOptions(): Args {


### PR DESCRIPTION
#### What it does

onAfterAttach cannot await initializeDiagram, so a rejected model load surfaced only as an unhandled rejection in the devtools. The user was left with an empty canvas and no indication that anything had gone wrong, let alone why.

- catch the rejection and render the reason in the widget, in place of the diagram, so it stays visible for as long as the editor is open
- keep logging the original error, including its stack, for diagnosis
- overlay the message instead of placing it in flow, the diagram claims the full height of the widget and would push it out of view
- look the diagram element up instead of reusing the created container, the viewer replaces the element it renders into

Fixes eclipse-glsp/glsp#1728

#### How to test

- Throw an error during diagram initialization
- Error should be rendered and logged

<img width="976" height="476" alt="image" src="https://github.com/user-attachments/assets/65a56db7-e9c1-4da7-9ed0-a74ab5432f2b" />


#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Changelog

<!-- Please check, when if it applies to your change. -->

- [ ] This PR should be mentioned in the changelog
- [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)
