### PR TITLE
Release v2.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Eclipse GLSP Theia Integration Changelog
 
-## v2.8.0 - active
+## [v2.8.0 - 28/08/2026](https://github.com/eclipse-glsp/glsp-theia-integration/releases/tag/v2.8.0)
 
 ### Changes
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ For details on building the project, please see the [README file of the theia-in
 ## Theia Version Compatibility
 
 | @eclipse-glsp/theia-integration | Theia               |
-| ------------------------------- | ------------------- |
+|---------------------------------|---------------------|
 | 0.8.0                           | <= 1.4.0            |
 | 0.9.0                           | >= 1.20.0 <= 1.25.0 |
 | 1.0.0                           | >= 1.25.0 <= 1.26.0 |
@@ -28,6 +28,7 @@ For details on building the project, please see the [README file of the theia-in
 | 2.6.0                           | >= 1.64.0           |
 | 2.7.0                           | >= 1.66.0           |
 | next                            | >= 1.66.0           |
+| 2.8.0                           | >= 1.66.0           |
 
 ### Potential Compatibility Issues
 

--- a/examples/browser-app/package.json
+++ b/examples/browser-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browser-app",
-  "version": "2.8.0-next",
+  "version": "2.8.0",
   "private": true,
   "scripts": {
     "build": "pnpm -w compile && pnpm rebuild && theia build --mode development",

--- a/examples/electron-app/package.json
+++ b/examples/electron-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-app",
-  "version": "2.8.0-next",
+  "version": "2.8.0",
   "private": true,
   "main": "lib/backend/electron-main.js",
   "scripts": {

--- a/examples/workflow-theia/package.json
+++ b/examples/workflow-theia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-glsp-examples/workflow-theia",
-  "version": "2.8.0-next",
+  "version": "2.8.0",
   "private": "true",
   "description": "Theia extension for the workflow GLSP example",
   "keywords": [
@@ -35,13 +35,13 @@
     "watch": "tsc -w"
   },
   "dependencies": {
-    "@eclipse-glsp-examples/workflow-glsp": "next",
-    "@eclipse-glsp-examples/workflow-server": "next",
-    "@eclipse-glsp-examples/workflow-server-bundled": "next",
-    "@eclipse-glsp/client": "next",
-    "@eclipse-glsp/layout-elk": "next",
-    "@eclipse-glsp/protocol": "next",
-    "@eclipse-glsp/server": "next",
+    "@eclipse-glsp-examples/workflow-glsp": "2.8.0",
+    "@eclipse-glsp-examples/workflow-server": "2.8.0",
+    "@eclipse-glsp-examples/workflow-server-bundled": "2.8.0",
+    "@eclipse-glsp/client": "2.8.0",
+    "@eclipse-glsp/layout-elk": "2.8.0",
+    "@eclipse-glsp/protocol": "2.8.0",
+    "@eclipse-glsp/server": "2.8.0",
     "@eclipse-glsp/theia-integration": "workspace:*",
     "@eclipse-glsp/theia-mcp-integration": "workspace:*"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parent",
-  "version": "2.8.0-next",
+  "version": "2.8.0",
   "private": true,
   "scripts": {
     "browser": "pnpm -C examples/browser-app",
@@ -29,7 +29,7 @@
     "watch:electron": "concurrently --kill-others -n tsc,browser -c red,yellow \"tsc -b -w --preserveWatchOutput\" \"pnpm electron watch\""
   },
   "devDependencies": {
-    "@eclipse-glsp/dev": "next",
+    "@eclipse-glsp/dev": "2.8.0",
     "@types/node": "22.x",
     "concurrently": "^8.2.2",
     "typescript": "^5.9.2"

--- a/packages/theia-integration/README.md
+++ b/packages/theia-integration/README.md
@@ -7,7 +7,7 @@ This project is built with `pnpm` and is available from npm via [@eclipse-glsp/t
 ## Theia Version Compatibility
 
 | @eclipse-glsp/theia-integration | Theia               |
-| ------------------------------- | ------------------- |
+|---------------------------------|---------------------|
 | 0.8.0                           | <= 1.4.0            |
 | 0.9.0                           | >= 1.20.0 <= 1.25.0 |
 | 1.0.0                           | >= 1.25.0 <= 1.26.0 |
@@ -26,6 +26,7 @@ This project is built with `pnpm` and is available from npm via [@eclipse-glsp/t
 | 2.6.0                           | >= 1.64.0           |
 | 2.7.0                           | >= 1.66.0           |
 | next                            | >= 1.66.0           |
+| 2.8.0                           | >= 1.66.0           |
 
 ### Potential Compatibility Issues
 

--- a/packages/theia-integration/package.json
+++ b/packages/theia-integration/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-glsp/theia-integration",
-  "version": "2.8.0-next",
+  "version": "2.8.0",
   "description": "Glue code to integrate GLSP clients into Eclipse Theia",
   "keywords": [
     "theia-extension",
@@ -45,8 +45,8 @@
     "watch": "tsc -w"
   },
   "dependencies": {
-    "@eclipse-glsp/client": "next",
-    "@eclipse-glsp/protocol": "next",
+    "@eclipse-glsp/client": "2.8.0",
+    "@eclipse-glsp/protocol": "2.8.0",
     "semver": "^7.8.4",
     "vscode-jsonrpc": "8.2.0",
     "ws": "^8.17.1"

--- a/packages/theia-mcp-integration/package.json
+++ b/packages/theia-mcp-integration/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-glsp/theia-mcp-integration",
-  "version": "2.8.0-next",
+  "version": "2.8.0",
   "description": "Glue code to integrate GLSP MCP servers into Eclipse Theia",
   "keywords": [
     "theia-extension",
@@ -45,8 +45,8 @@
     "watch": "tsc -w"
   },
   "dependencies": {
-    "@eclipse-glsp/client": "next",
-    "@eclipse-glsp/protocol": "next",
+    "@eclipse-glsp/client": "2.8.0",
+    "@eclipse-glsp/protocol": "2.8.0",
     "@eclipse-glsp/theia-integration": "workspace:*"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,8 +14,8 @@ importers:
   .:
     devDependencies:
       '@eclipse-glsp/dev':
-        specifier: next
-        version: 2.8.0-next.19(@types/node@22.19.21)(@typescript-eslint/utils@8.61.0(eslint@10.5.0)(typescript@5.9.3))(esbuild@0.28.1)(supports-color@8.1.1)(terser@5.48.0)(typescript@5.9.3)(yaml@2.9.0)
+        specifier: 2.8.0
+        version: 2.8.0(@types/node@22.19.21)(@typescript-eslint/utils@8.61.0(eslint@10.5.0)(typescript@5.9.3))(esbuild@0.28.1)(terser@5.48.0)(typescript@5.9.3)(yaml@2.9.0)
       '@types/node':
         specifier: 22.x
         version: 22.19.21
@@ -142,26 +142,26 @@ importers:
   examples/workflow-theia:
     dependencies:
       '@eclipse-glsp-examples/workflow-glsp':
-        specifier: next
-        version: 2.8.0-next.16(inversify@6.2.2(reflect-metadata@0.2.2))(reflect-metadata@0.2.2)
+        specifier: 2.8.0
+        version: 2.8.0(inversify@6.2.2(reflect-metadata@0.2.2))(reflect-metadata@0.2.2)
       '@eclipse-glsp-examples/workflow-server':
-        specifier: next
-        version: 2.8.0-next.7(hono@4.12.25)
+        specifier: 2.8.0
+        version: 2.8.0(hono@4.12.25)
       '@eclipse-glsp-examples/workflow-server-bundled':
-        specifier: next
-        version: 2.8.0-next.7
+        specifier: 2.8.0
+        version: 2.8.0
       '@eclipse-glsp/client':
-        specifier: next
-        version: 2.8.0-next.16(inversify@6.2.2(reflect-metadata@0.2.2))(reflect-metadata@0.2.2)
+        specifier: 2.8.0
+        version: 2.8.0(inversify@6.2.2(reflect-metadata@0.2.2))(reflect-metadata@0.2.2)
       '@eclipse-glsp/layout-elk':
-        specifier: next
-        version: 2.8.0-next.7(inversify@6.2.2(reflect-metadata@0.2.2))(reflect-metadata@0.2.2)
+        specifier: 2.8.0
+        version: 2.8.0(inversify@6.2.2(reflect-metadata@0.2.2))(reflect-metadata@0.2.2)
       '@eclipse-glsp/protocol':
-        specifier: next
-        version: 2.8.0-next.16(inversify@6.2.2(reflect-metadata@0.2.2))(reflect-metadata@0.2.2)
+        specifier: 2.8.0
+        version: 2.8.0(inversify@6.2.2(reflect-metadata@0.2.2))(reflect-metadata@0.2.2)
       '@eclipse-glsp/server':
-        specifier: next
-        version: 2.8.0-next.7(inversify@6.2.2(reflect-metadata@0.2.2))(reflect-metadata@0.2.2)
+        specifier: 2.8.0
+        version: 2.8.0(inversify@6.2.2(reflect-metadata@0.2.2))(reflect-metadata@0.2.2)
       '@eclipse-glsp/theia-integration':
         specifier: workspace:*
         version: link:../../packages/theia-integration
@@ -172,11 +172,11 @@ importers:
   packages/theia-integration:
     dependencies:
       '@eclipse-glsp/client':
-        specifier: next
-        version: 2.8.0-next.16(inversify@6.2.2(reflect-metadata@0.2.2))(reflect-metadata@0.2.2)
+        specifier: 2.8.0
+        version: 2.8.0(inversify@6.2.2(reflect-metadata@0.2.2))(reflect-metadata@0.2.2)
       '@eclipse-glsp/protocol':
-        specifier: next
-        version: 2.8.0-next.16(inversify@6.2.2(reflect-metadata@0.2.2))(reflect-metadata@0.2.2)
+        specifier: 2.8.0
+        version: 2.8.0(inversify@6.2.2(reflect-metadata@0.2.2))(reflect-metadata@0.2.2)
       semver:
         specifier: ^7.8.4
         version: 7.8.4
@@ -194,11 +194,11 @@ importers:
   packages/theia-mcp-integration:
     dependencies:
       '@eclipse-glsp/client':
-        specifier: next
-        version: 2.8.0-next.16(inversify@6.2.2(reflect-metadata@0.2.2))(reflect-metadata@0.2.2)
+        specifier: 2.8.0
+        version: 2.8.0(inversify@6.2.2(reflect-metadata@0.2.2))(reflect-metadata@0.2.2)
       '@eclipse-glsp/protocol':
-        specifier: next
-        version: 2.8.0-next.16(inversify@6.2.2(reflect-metadata@0.2.2))(reflect-metadata@0.2.2)
+        specifier: 2.8.0
+        version: 2.8.0(inversify@6.2.2(reflect-metadata@0.2.2))(reflect-metadata@0.2.2)
       '@eclipse-glsp/theia-integration':
         specifier: workspace:*
         version: link:../theia-integration
@@ -745,39 +745,39 @@ packages:
     resolution: {integrity: sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==}
     engines: {node: '>=10.0.0'}
 
-  '@eclipse-glsp-examples/workflow-glsp@2.8.0-next.16':
-    resolution: {integrity: sha512-qxCxAR3XDAMxU3wEgJFYypaqlrw+lP04KTPU+iyUYxFt1ke+nv5XatOe1v9oGTRolsTKD2vKWyAvUDjQtzsVgg==}
+  '@eclipse-glsp-examples/workflow-glsp@2.8.0':
+    resolution: {integrity: sha512-i7ixCkQeZkTu9vLA8DI1A/GZ4cquUx5uKKROlYJPVolLSeXu3Di63oCkMyl0lhaOP0J11ZrUJtAJ8xnMbK845w==}
     peerDependencies:
       inversify: ^6.1.3
       reflect-metadata: ^0.2.2
 
-  '@eclipse-glsp-examples/workflow-server-bundled@2.8.0-next.7':
-    resolution: {integrity: sha512-DqJNKZESP1srqmWVDIip3c6o4ARHl1TeMlkkIEZZ45Gn0HBNmgr5Z48kgJ1iKkesHeGgEyn5b8Ohm+4LEBo/HQ==}
+  '@eclipse-glsp-examples/workflow-server-bundled@2.8.0':
+    resolution: {integrity: sha512-i/KvHCQaQUeRN9d3G59g38ScitRLg92W/mN0keGstDFlhtj0XW11BvNbHT94RseWEiMaVuD/vWtJX7fnanL02A==}
 
-  '@eclipse-glsp-examples/workflow-server@2.8.0-next.7':
-    resolution: {integrity: sha512-+fT9AGRbDemSUGjWzfr+J4EeQ3Y6dhCM1QW5oibEjfNTEcWrWIk2W21n0fT+eFR5dtnzF+3HWENRCvQBDrhkMA==}
+  '@eclipse-glsp-examples/workflow-server@2.8.0':
+    resolution: {integrity: sha512-97STJnMJbn/d0CkTgwHs6gFzSILW4nF0zkld+MGjccMGc1pvcGhwjsnc4yjv+S7s3bef4JRCW8InSxyCkXI8jw==}
 
-  '@eclipse-glsp/cli@2.8.0-next.19':
-    resolution: {integrity: sha512-t+PEnSqOjFXznmAexX7Ekc+jLUIqPlIkUnm1laWi/D9mFHo67KRQ7563qmrTn4Wi0NAsdWeXToFBxFxG6/PfaQ==}
+  '@eclipse-glsp/cli@2.8.0':
+    resolution: {integrity: sha512-ILZKIk3PAxD8sOfgAFr8Qnvyi8SoRs2F/UVoqWGHyhwMqpAdexn/s2VRcMV41h9FC/b/AZ+zc6/BbFTa0222Ew==}
     hasBin: true
 
-  '@eclipse-glsp/client@2.8.0-next.16':
-    resolution: {integrity: sha512-tIrnT4FrRL1FoDVfu+1NAPbwIJjjj6Q0w9k96uH02ThfWBUnhdGMNDRZT6L9gmg6yOpt8Pbr9RDJMpBbfWO8Mg==}
+  '@eclipse-glsp/client@2.8.0':
+    resolution: {integrity: sha512-dR3mQ3jMUIxMic0Bd8cxg6POeMM8o2i7XVDMTP8gxcsdezk2YipHQRYYQ6YDyk3UPqxoBhwyD0a14qFqTJDYIQ==}
     peerDependencies:
       inversify: ^6.1.3
       reflect-metadata: ^0.2.2
 
-  '@eclipse-glsp/config-test@2.8.0-next.19':
-    resolution: {integrity: sha512-kLTnX6MGyKvI9u6TxZek3AQaUcdI/TMuhDBwB0+zGma3lwuGSvXqmqkYDdXrGN5ntuYoq7sfZBuCy+67LO7SXQ==}
+  '@eclipse-glsp/config-test@2.8.0':
+    resolution: {integrity: sha512-r8WGm12zJd7wmIWoMz5+akFmqC+ZucA6l0z8+gX38i/rwZvz2GVeX4LFkOa/eWodkLVVJvjLWjjHcwpOvCvbIA==}
 
-  '@eclipse-glsp/config@2.8.0-next.19':
-    resolution: {integrity: sha512-Jxb3Zq9pw1waIbBINTEy9+7clcB939bOW+Lo56GB38LBd4HkQX82/Gh0EZN7PZhMP/mCfo4J6XGOK0m7q7qbpg==}
+  '@eclipse-glsp/config@2.8.0':
+    resolution: {integrity: sha512-RL/V9NMsjQ2bX9+d4Sbl1fxf7h+eLH8T8mMnjzd5MqvZdJYyUP7n+Yt5vyXenPRuXMpu4jTX9h3HL+u4mziY8g==}
 
-  '@eclipse-glsp/dev@2.8.0-next.19':
-    resolution: {integrity: sha512-Kairzb+bgxSVuBcVPBLxWNbJevMm3nYqbTY1WaY8RXjDCRSW03U50et2AgC2L/F8I1gmJGZLfMF4BhxJzehOIg==}
+  '@eclipse-glsp/dev@2.8.0':
+    resolution: {integrity: sha512-bueBgpXygZQoYdB5lbCd/YpQGrWVUWTea+FK5Ff5cNNFrSEK/dENXPMIz5p9hjxqaQIVG00WLKs3VE6EUTu9WQ==}
 
-  '@eclipse-glsp/eslint-config@2.8.0-next.19':
-    resolution: {integrity: sha512-QlXER0UYOaYT7WpzYpuHbLgjaeKTTjd0USddgvvuWneIwvsRRjaXk9QI0RKeCIKvJHjpzPOFsmW8RTjzp/EMhw==}
+  '@eclipse-glsp/eslint-config@2.8.0':
+    resolution: {integrity: sha512-3hJbDif0O028+59TMXbkv6lzeIxuYZiSsUwmYSbik3NUK+vvp+ipP10mj8m/glISiksAZXa6HRIuOvxaBm2ZYA==}
     peerDependencies:
       '@eslint/js': ^10.0.1
       '@stylistic/eslint-plugin': ^5.10.0
@@ -790,20 +790,20 @@ packages:
       globals: ^17.6.0
       typescript-eslint: ^8.0.0
 
-  '@eclipse-glsp/graph@2.8.0-next.7':
-    resolution: {integrity: sha512-F7PuLVe9cxRqUP56Itd2Qb44hEybQyxUKedZ6+ntmjveQ+ASUWqt1t+vnPlVbrfmlHbJidGFixY/ZD7VQuOHrQ==}
+  '@eclipse-glsp/graph@2.8.0':
+    resolution: {integrity: sha512-FNLQ27K5w42ygxPnWHEXOLChQR3HBXou5J5UMXhTKJJTFy/lbGyxCmtsKDZ72rvj8l3Wyxg15SRLQUjykFxPbA==}
 
-  '@eclipse-glsp/layout-elk@2.8.0-next.7':
-    resolution: {integrity: sha512-ASyIXmx+zEFOu9wmXtTdTMKteT2kAV/FTxmEl1sdNcIzU/P9T4CAsSUX/xrX3lpjRKxy8kgnrclgNLaeGBRJHw==}
+  '@eclipse-glsp/layout-elk@2.8.0':
+    resolution: {integrity: sha512-Z5N7Q8f4vgH1GIZA0TrXv2EDL50YF2HXehH9yoxnkgsKAa9Id0RZlLMKzWRbYYyaNzhrcD1vXg1iY/SBV0Kabg==}
     peerDependencies:
       inversify: ^6.1.3
       reflect-metadata: ^0.2.2
 
-  '@eclipse-glsp/prettier-config@2.8.0-next.19':
-    resolution: {integrity: sha512-pBLY7CQYHl0pAwSTiNPr4j182sSi0LH9ZwL+Ka0EhvXMMxUfvPMaEmKFi5nXuxVigeOFpRcTaRyuJU0LH15AqA==}
+  '@eclipse-glsp/prettier-config@2.8.0':
+    resolution: {integrity: sha512-Or/vVcsHgN/+q12hcwwRpXragXv43g7kvXlb7HLigltDrlf5W9Mfg3umhUFpC7PTYsdHM7FVi9cwp51ggDBDWQ==}
 
-  '@eclipse-glsp/protocol@2.8.0-next.16':
-    resolution: {integrity: sha512-NAd+hvZxC2ex95dtIHrBMl2+warBprkEGhVoYtqHGc8eZsWg5BhlqCt6oUdx36JP3V6HdxooD+vVgqowqGeJdA==}
+  '@eclipse-glsp/protocol@2.8.0':
+    resolution: {integrity: sha512-Dd9sVtX1kRkvWnGeyF9pC2DrHUDYaDgm0TukuRIaw4SvlKeKK2w48c2hmpRkKpsIKbWw8lk8R53FDKTqE52jnQ==}
     peerDependencies:
       inversify: ^6.1.3
       reflect-metadata: ^0.2.2
@@ -813,31 +813,31 @@ packages:
       reflect-metadata:
         optional: true
 
-  '@eclipse-glsp/server-mcp@2.8.0-next.7':
-    resolution: {integrity: sha512-eXL8Ha2rDqBI5Ou9qVkYVzuEls50WwCIQHijddqPZ21C4tGoyIv485PIJwU7m+h3NDJmvCKE9TEw7I0yabXSoA==}
+  '@eclipse-glsp/server-mcp@2.8.0':
+    resolution: {integrity: sha512-uQmlnT2pb3JRvJxJOdQAVk6sFKVwOIGzDqt+Ddg7anGHg63VJJ0chZxXfz1eDbRYpfIb9lc5p9lMON6ZduUpkw==}
     peerDependencies:
       inversify: ^6.1.3
       reflect-metadata: ^0.2.2
 
-  '@eclipse-glsp/server@2.8.0-next.7':
-    resolution: {integrity: sha512-k+n3O/jM6XRL0KNlz3suE8I8P5pvVi08IBspJR15GKIEFCjFIES7vm5/TuBzfoUfLddgURFFko9rPqmNS8Zm7A==}
+  '@eclipse-glsp/server@2.8.0':
+    resolution: {integrity: sha512-75jROuMd/la6YPq84R97oxxnu+R1SOXvkzEis+wu1c0By3VYriL5ur1ehRbEqdKMklQd4as9+ayuZaSojdbH0A==}
     peerDependencies:
       inversify: ^6.1.3
       reflect-metadata: ^0.2.2
 
-  '@eclipse-glsp/sprotty@2.8.0-next.16':
-    resolution: {integrity: sha512-ogxluW5NToyvijpxuvJyte61Hf29oWeAVEaMaGnQX9xc4SsJCE5HgocSK8BtVRc5Q8no+HNMrWGa07sgfDV6gg==}
+  '@eclipse-glsp/sprotty@2.8.0':
+    resolution: {integrity: sha512-gT9JnPsecfCU2ycXCceTj66Q3UsVgya+9+JZd51b1q7Q/6zusH51x1/FkEGBbfPWpimG3awpNLV7SDdZEidNOg==}
     peerDependencies:
       inversify: ^6.1.3
       reflect-metadata: ^0.2.2
 
-  '@eclipse-glsp/ts-config@2.8.0-next.19':
-    resolution: {integrity: sha512-zH7UW1+upPxvGljLMTuOP+S7yfXtxyvDcXnkc+iPWtzZORzcLm7IZRYfzoC6EKx45cllyasiLwV5ebhk6a/QOw==}
+  '@eclipse-glsp/ts-config@2.8.0':
+    resolution: {integrity: sha512-H7Eb5bfE7IhzEvOi7t80y07dIMmC62jTAF1baWvP8T4HRHOuQH/pOnmlN2/e0tQe1CYpykGZMMO0YFO8+xuDSA==}
     peerDependencies:
       typescript: '>=5.5'
 
-  '@eclipse-glsp/vitest-config@2.8.0-next.19':
-    resolution: {integrity: sha512-Kq2VLBCTbp2keeNnNK6Io06iTSepzsQ/Ql3FCrXsEMyDziYYKsPsmZ1wbMbCWFoziQokWzTf4pkTcwVCymPWCQ==}
+  '@eclipse-glsp/vitest-config@2.8.0':
+    resolution: {integrity: sha512-8+ZZRbwNBCe9283F9TEjNpWdGJdCQGUfuUtMcgGCBbiAY3h+/0Y147KKAPkcBe3vd17po8okFmOqFdqbetqnkw==}
     peerDependencies:
       '@vitest/coverage-v8': '>=4.0.0'
       vitest: '>=4.0.0'
@@ -1231,12 +1231,6 @@ packages:
     resolution: {integrity: sha512-CmCXPQrkbwExx3j946/PtHWHbYJiCRBRDl4BlkRQcJB/YOwQxJRTpoo7aTsortjgoJ1x7opzTSxn7C+ASSLVjQ==}
     cpu: [x64]
     os: [win32]
-
-  '@napi-rs/wasm-runtime@1.1.5':
-    resolution: {integrity: sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==}
-    peerDependencies:
-      '@emnapi/core': ^1.7.1
-      '@emnapi/runtime': ^1.7.1
 
   '@napi-rs/wasm-runtime@1.1.6':
     resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
@@ -1655,9 +1649,6 @@ packages:
   '@tootallnate/once@2.0.1':
     resolution: {integrity: sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==}
     engines: {node: '>= 10'}
-
-  '@tybys/wasm-util@0.10.2':
-    resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
 
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
@@ -7644,21 +7635,21 @@ snapshots:
 
   '@discoveryjs/json-ext@0.5.7': {}
 
-  '@eclipse-glsp-examples/workflow-glsp@2.8.0-next.16(inversify@6.2.2(reflect-metadata@0.2.2))(reflect-metadata@0.2.2)':
+  '@eclipse-glsp-examples/workflow-glsp@2.8.0(inversify@6.2.2(reflect-metadata@0.2.2))(reflect-metadata@0.2.2)':
     dependencies:
-      '@eclipse-glsp/client': 2.8.0-next.16(inversify@6.2.2(reflect-metadata@0.2.2))(reflect-metadata@0.2.2)
+      '@eclipse-glsp/client': 2.8.0(inversify@6.2.2(reflect-metadata@0.2.2))(reflect-metadata@0.2.2)
       balloon-css: 0.5.2
       inversify: 6.2.2(reflect-metadata@0.2.2)
       reflect-metadata: 0.2.2
       snabbdom: 3.5.1
 
-  '@eclipse-glsp-examples/workflow-server-bundled@2.8.0-next.7': {}
+  '@eclipse-glsp-examples/workflow-server-bundled@2.8.0': {}
 
-  '@eclipse-glsp-examples/workflow-server@2.8.0-next.7(hono@4.12.25)':
+  '@eclipse-glsp-examples/workflow-server@2.8.0(hono@4.12.25)':
     dependencies:
-      '@eclipse-glsp/layout-elk': 2.8.0-next.7(inversify@6.2.2(reflect-metadata@0.2.2))(reflect-metadata@0.2.2)
-      '@eclipse-glsp/server': 2.8.0-next.7(inversify@6.2.2(reflect-metadata@0.2.2))(reflect-metadata@0.2.2)
-      '@eclipse-glsp/server-mcp': 2.8.0-next.7(hono@4.12.25)(inversify@6.2.2(reflect-metadata@0.2.2))(reflect-metadata@0.2.2)
+      '@eclipse-glsp/layout-elk': 2.8.0(inversify@6.2.2(reflect-metadata@0.2.2))(reflect-metadata@0.2.2)
+      '@eclipse-glsp/server': 2.8.0(inversify@6.2.2(reflect-metadata@0.2.2))(reflect-metadata@0.2.2)
+      '@eclipse-glsp/server-mcp': 2.8.0(hono@4.12.25)(inversify@6.2.2(reflect-metadata@0.2.2))(reflect-metadata@0.2.2)
       inversify: 6.2.2(reflect-metadata@0.2.2)
       reflect-metadata: 0.2.2
     transitivePeerDependencies:
@@ -7668,11 +7659,11 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@eclipse-glsp/cli@2.8.0-next.19': {}
+  '@eclipse-glsp/cli@2.8.0': {}
 
-  '@eclipse-glsp/client@2.8.0-next.16(inversify@6.2.2(reflect-metadata@0.2.2))(reflect-metadata@0.2.2)':
+  '@eclipse-glsp/client@2.8.0(inversify@6.2.2(reflect-metadata@0.2.2))(reflect-metadata@0.2.2)':
     dependencies:
-      '@eclipse-glsp/sprotty': 2.8.0-next.16(inversify@6.2.2(reflect-metadata@0.2.2))(reflect-metadata@0.2.2)
+      '@eclipse-glsp/sprotty': 2.8.0(inversify@6.2.2(reflect-metadata@0.2.2))(reflect-metadata@0.2.2)
       '@vscode/codicons': 0.0.44
       autocompleter: 9.3.2
       file-saver: 2.0.5
@@ -7681,9 +7672,9 @@ snapshots:
       snabbdom: 3.5.1
       vscode-jsonrpc: 8.2.0
 
-  '@eclipse-glsp/config-test@2.8.0-next.19(@types/node@22.19.21)(esbuild@0.28.1)(terser@5.48.0)(yaml@2.9.0)':
+  '@eclipse-glsp/config-test@2.8.0(@types/node@22.19.21)(esbuild@0.28.1)(terser@5.48.0)(yaml@2.9.0)':
     dependencies:
-      '@eclipse-glsp/vitest-config': 2.8.0-next.19(@vitest/coverage-v8@4.1.9)(vitest@4.1.9)
+      '@eclipse-glsp/vitest-config': 2.8.0(@vitest/coverage-v8@4.1.9)(vitest@4.1.9)
       '@vitest/coverage-v8': 4.1.9(vitest@4.1.9)
       vitest: 4.1.9(@types/node@22.19.21)(@vitest/coverage-v8@4.1.9)(esbuild@0.28.1)(terser@5.48.0)(yaml@2.9.0)
     transitivePeerDependencies:
@@ -7711,23 +7702,23 @@ snapshots:
       - tsx
       - yaml
 
-  '@eclipse-glsp/config@2.8.0-next.19(@typescript-eslint/utils@8.61.0(eslint@10.5.0)(typescript@5.9.3))(supports-color@8.1.1)(typescript@5.9.3)':
+  '@eclipse-glsp/config@2.8.0(@typescript-eslint/utils@8.61.0(eslint@10.5.0)(typescript@5.9.3))(typescript@5.9.3)':
     dependencies:
-      '@eclipse-glsp/eslint-config': 2.8.0-next.19(@eslint/js@10.0.1(eslint@10.5.0))(@stylistic/eslint-plugin@5.10.0(eslint@10.5.0))(@tony.ganchev/eslint-plugin-header@3.4.4(eslint@10.5.0))(eslint-config-prettier@10.1.8(eslint@10.5.0))(eslint-import-resolver-typescript@4.4.5(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.61.0(eslint@10.5.0)(typescript@5.9.3))(eslint@10.5.0)(supports-color@8.1.1))(eslint@10.5.0)(supports-color@8.1.1))(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.61.0(eslint@10.5.0)(typescript@5.9.3))(eslint@10.5.0)(supports-color@8.1.1))(eslint-plugin-no-null@1.0.2(eslint@10.5.0))(eslint@10.5.0)(globals@17.6.0)(typescript-eslint@8.61.0(eslint@10.5.0)(supports-color@8.1.1)(typescript@5.9.3))
-      '@eclipse-glsp/prettier-config': 2.8.0-next.19(prettier@3.8.4)
-      '@eclipse-glsp/ts-config': 2.8.0-next.19(typescript@5.9.3)
+      '@eclipse-glsp/eslint-config': 2.8.0(@eslint/js@10.0.1(eslint@10.5.0))(@stylistic/eslint-plugin@5.10.0(eslint@10.5.0))(@tony.ganchev/eslint-plugin-header@3.4.4(eslint@10.5.0))(eslint-config-prettier@10.1.8(eslint@10.5.0))(eslint-import-resolver-typescript@4.4.5(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.61.0(eslint@10.5.0)(typescript@5.9.3))(eslint@10.5.0))(eslint@10.5.0))(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.61.0(eslint@10.5.0)(typescript@5.9.3))(eslint@10.5.0))(eslint-plugin-no-null@1.0.2(eslint@10.5.0))(eslint@10.5.0)(globals@17.6.0)(typescript-eslint@8.61.0(eslint@10.5.0)(typescript@5.9.3))
+      '@eclipse-glsp/prettier-config': 2.8.0(prettier@3.8.4)
+      '@eclipse-glsp/ts-config': 2.8.0(typescript@5.9.3)
       '@eslint/js': 10.0.1(eslint@10.5.0)
       '@stylistic/eslint-plugin': 5.10.0(eslint@10.5.0)
       '@tony.ganchev/eslint-plugin-header': 3.4.4(eslint@10.5.0)
       eslint: 10.5.0
       eslint-config-prettier: 10.1.8(eslint@10.5.0)
-      eslint-import-resolver-typescript: 4.4.5(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.61.0(eslint@10.5.0)(typescript@5.9.3))(eslint@10.5.0)(supports-color@8.1.1))(eslint@10.5.0)(supports-color@8.1.1)
-      eslint-plugin-import-x: 4.16.2(@typescript-eslint/utils@8.61.0(eslint@10.5.0)(typescript@5.9.3))(eslint@10.5.0)(supports-color@8.1.1)
+      eslint-import-resolver-typescript: 4.4.5(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.61.0(eslint@10.5.0)(typescript@5.9.3))(eslint@10.5.0))(eslint@10.5.0)
+      eslint-plugin-import-x: 4.16.2(@typescript-eslint/utils@8.61.0(eslint@10.5.0)(typescript@5.9.3))(eslint@10.5.0)
       eslint-plugin-no-null: 1.0.2(eslint@10.5.0)
       globals: 17.6.0
       prettier: 3.8.4
       rimraf: 6.1.3
-      typescript-eslint: 8.61.0(eslint@10.5.0)(supports-color@8.1.1)(typescript@5.9.3)
+      typescript-eslint: 8.61.0(eslint@10.5.0)(typescript@5.9.3)
     transitivePeerDependencies:
       - '@typescript-eslint/utils'
       - eslint-import-resolver-node
@@ -7736,11 +7727,11 @@ snapshots:
       - supports-color
       - typescript
 
-  '@eclipse-glsp/dev@2.8.0-next.19(@types/node@22.19.21)(@typescript-eslint/utils@8.61.0(eslint@10.5.0)(typescript@5.9.3))(esbuild@0.28.1)(supports-color@8.1.1)(terser@5.48.0)(typescript@5.9.3)(yaml@2.9.0)':
+  '@eclipse-glsp/dev@2.8.0(@types/node@22.19.21)(@typescript-eslint/utils@8.61.0(eslint@10.5.0)(typescript@5.9.3))(esbuild@0.28.1)(terser@5.48.0)(typescript@5.9.3)(yaml@2.9.0)':
     dependencies:
-      '@eclipse-glsp/cli': 2.8.0-next.19
-      '@eclipse-glsp/config': 2.8.0-next.19(@typescript-eslint/utils@8.61.0(eslint@10.5.0)(typescript@5.9.3))(supports-color@8.1.1)(typescript@5.9.3)
-      '@eclipse-glsp/config-test': 2.8.0-next.19(@types/node@22.19.21)(esbuild@0.28.1)(terser@5.48.0)(yaml@2.9.0)
+      '@eclipse-glsp/cli': 2.8.0
+      '@eclipse-glsp/config': 2.8.0(@typescript-eslint/utils@8.61.0(eslint@10.5.0)(typescript@5.9.3))(typescript@5.9.3)
+      '@eclipse-glsp/config-test': 2.8.0(@types/node@22.19.21)(esbuild@0.28.1)(terser@5.48.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@opentelemetry/api'
@@ -7771,29 +7762,29 @@ snapshots:
       - typescript
       - yaml
 
-  '@eclipse-glsp/eslint-config@2.8.0-next.19(@eslint/js@10.0.1(eslint@10.5.0))(@stylistic/eslint-plugin@5.10.0(eslint@10.5.0))(@tony.ganchev/eslint-plugin-header@3.4.4(eslint@10.5.0))(eslint-config-prettier@10.1.8(eslint@10.5.0))(eslint-import-resolver-typescript@4.4.5(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.61.0(eslint@10.5.0)(typescript@5.9.3))(eslint@10.5.0)(supports-color@8.1.1))(eslint@10.5.0)(supports-color@8.1.1))(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.61.0(eslint@10.5.0)(typescript@5.9.3))(eslint@10.5.0)(supports-color@8.1.1))(eslint-plugin-no-null@1.0.2(eslint@10.5.0))(eslint@10.5.0)(globals@17.6.0)(typescript-eslint@8.61.0(eslint@10.5.0)(supports-color@8.1.1)(typescript@5.9.3))':
+  '@eclipse-glsp/eslint-config@2.8.0(@eslint/js@10.0.1(eslint@10.5.0))(@stylistic/eslint-plugin@5.10.0(eslint@10.5.0))(@tony.ganchev/eslint-plugin-header@3.4.4(eslint@10.5.0))(eslint-config-prettier@10.1.8(eslint@10.5.0))(eslint-import-resolver-typescript@4.4.5(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.61.0(eslint@10.5.0)(typescript@5.9.3))(eslint@10.5.0))(eslint@10.5.0))(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.61.0(eslint@10.5.0)(typescript@5.9.3))(eslint@10.5.0))(eslint-plugin-no-null@1.0.2(eslint@10.5.0))(eslint@10.5.0)(globals@17.6.0)(typescript-eslint@8.61.0(eslint@10.5.0)(typescript@5.9.3))':
     dependencies:
       '@eslint/js': 10.0.1(eslint@10.5.0)
       '@stylistic/eslint-plugin': 5.10.0(eslint@10.5.0)
       '@tony.ganchev/eslint-plugin-header': 3.4.4(eslint@10.5.0)
       eslint: 10.5.0
       eslint-config-prettier: 10.1.8(eslint@10.5.0)
-      eslint-import-resolver-typescript: 4.4.5(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.61.0(eslint@10.5.0)(typescript@5.9.3))(eslint@10.5.0)(supports-color@8.1.1))(eslint@10.5.0)(supports-color@8.1.1)
-      eslint-plugin-import-x: 4.16.2(@typescript-eslint/utils@8.61.0(eslint@10.5.0)(typescript@5.9.3))(eslint@10.5.0)(supports-color@8.1.1)
+      eslint-import-resolver-typescript: 4.4.5(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.61.0(eslint@10.5.0)(typescript@5.9.3))(eslint@10.5.0))(eslint@10.5.0)
+      eslint-plugin-import-x: 4.16.2(@typescript-eslint/utils@8.61.0(eslint@10.5.0)(typescript@5.9.3))(eslint@10.5.0)
       eslint-plugin-no-null: 1.0.2(eslint@10.5.0)
       globals: 17.6.0
-      typescript-eslint: 8.61.0(eslint@10.5.0)(supports-color@8.1.1)(typescript@5.9.3)
+      typescript-eslint: 8.61.0(eslint@10.5.0)(typescript@5.9.3)
 
-  '@eclipse-glsp/graph@2.8.0-next.7(inversify@6.2.2(reflect-metadata@0.2.2))(reflect-metadata@0.2.2)':
+  '@eclipse-glsp/graph@2.8.0(inversify@6.2.2(reflect-metadata@0.2.2))(reflect-metadata@0.2.2)':
     dependencies:
-      '@eclipse-glsp/protocol': 2.8.0-next.16(inversify@6.2.2(reflect-metadata@0.2.2))(reflect-metadata@0.2.2)
+      '@eclipse-glsp/protocol': 2.8.0(inversify@6.2.2(reflect-metadata@0.2.2))(reflect-metadata@0.2.2)
     transitivePeerDependencies:
       - inversify
       - reflect-metadata
 
-  '@eclipse-glsp/layout-elk@2.8.0-next.7(inversify@6.2.2(reflect-metadata@0.2.2))(reflect-metadata@0.2.2)':
+  '@eclipse-glsp/layout-elk@2.8.0(inversify@6.2.2(reflect-metadata@0.2.2))(reflect-metadata@0.2.2)':
     dependencies:
-      '@eclipse-glsp/server': 2.8.0-next.7(inversify@6.2.2(reflect-metadata@0.2.2))(reflect-metadata@0.2.2)
+      '@eclipse-glsp/server': 2.8.0(inversify@6.2.2(reflect-metadata@0.2.2))(reflect-metadata@0.2.2)
       elkjs: 0.11.1
       inversify: 6.2.2(reflect-metadata@0.2.2)
       reflect-metadata: 0.2.2
@@ -7801,13 +7792,13 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@eclipse-glsp/prettier-config@2.8.0-next.19(prettier@3.8.4)':
+  '@eclipse-glsp/prettier-config@2.8.0(prettier@3.8.4)':
     dependencies:
       prettier-plugin-packagejson: 3.0.2(prettier@3.8.4)
     transitivePeerDependencies:
       - prettier
 
-  '@eclipse-glsp/protocol@2.8.0-next.16(inversify@6.2.2(reflect-metadata@0.2.2))(reflect-metadata@0.2.2)':
+  '@eclipse-glsp/protocol@2.8.0(inversify@6.2.2(reflect-metadata@0.2.2))(reflect-metadata@0.2.2)':
     dependencies:
       sprotty-protocol: 1.4.0
       uuid: 14.0.0
@@ -7816,9 +7807,9 @@ snapshots:
       inversify: 6.2.2(reflect-metadata@0.2.2)
       reflect-metadata: 0.2.2
 
-  '@eclipse-glsp/server-mcp@2.8.0-next.7(hono@4.12.25)(inversify@6.2.2(reflect-metadata@0.2.2))(reflect-metadata@0.2.2)':
+  '@eclipse-glsp/server-mcp@2.8.0(hono@4.12.25)(inversify@6.2.2(reflect-metadata@0.2.2))(reflect-metadata@0.2.2)':
     dependencies:
-      '@eclipse-glsp/server': 2.8.0-next.7(inversify@6.2.2(reflect-metadata@0.2.2))(reflect-metadata@0.2.2)
+      '@eclipse-glsp/server': 2.8.0(inversify@6.2.2(reflect-metadata@0.2.2))(reflect-metadata@0.2.2)
       '@hono/node-server': 1.19.14(hono@4.12.25)
       '@modelcontextprotocol/sdk': 1.29.0(supports-color@8.1.1)
       inversify: 6.2.2(reflect-metadata@0.2.2)
@@ -7831,10 +7822,10 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@eclipse-glsp/server@2.8.0-next.7(inversify@6.2.2(reflect-metadata@0.2.2))(reflect-metadata@0.2.2)':
+  '@eclipse-glsp/server@2.8.0(inversify@6.2.2(reflect-metadata@0.2.2))(reflect-metadata@0.2.2)':
     dependencies:
-      '@eclipse-glsp/graph': 2.8.0-next.7(inversify@6.2.2(reflect-metadata@0.2.2))(reflect-metadata@0.2.2)
-      '@eclipse-glsp/protocol': 2.8.0-next.16(inversify@6.2.2(reflect-metadata@0.2.2))(reflect-metadata@0.2.2)
+      '@eclipse-glsp/graph': 2.8.0(inversify@6.2.2(reflect-metadata@0.2.2))(reflect-metadata@0.2.2)
+      '@eclipse-glsp/protocol': 2.8.0(inversify@6.2.2(reflect-metadata@0.2.2))(reflect-metadata@0.2.2)
       commander: 14.0.3
       fast-json-patch: 3.1.1
       inversify: 6.2.2(reflect-metadata@0.2.2)
@@ -7846,9 +7837,9 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@eclipse-glsp/sprotty@2.8.0-next.16(inversify@6.2.2(reflect-metadata@0.2.2))(reflect-metadata@0.2.2)':
+  '@eclipse-glsp/sprotty@2.8.0(inversify@6.2.2(reflect-metadata@0.2.2))(reflect-metadata@0.2.2)':
     dependencies:
-      '@eclipse-glsp/protocol': 2.8.0-next.16(inversify@6.2.2(reflect-metadata@0.2.2))(reflect-metadata@0.2.2)
+      '@eclipse-glsp/protocol': 2.8.0(inversify@6.2.2(reflect-metadata@0.2.2))(reflect-metadata@0.2.2)
       autocompleter: 9.3.2
       inversify: 6.2.2(reflect-metadata@0.2.2)
       reflect-metadata: 0.2.2
@@ -7857,11 +7848,11 @@ snapshots:
       sprotty-protocol: 1.4.0
       vscode-jsonrpc: 8.2.0
 
-  '@eclipse-glsp/ts-config@2.8.0-next.19(typescript@5.9.3)':
+  '@eclipse-glsp/ts-config@2.8.0(typescript@5.9.3)':
     dependencies:
       typescript: 5.9.3
 
-  '@eclipse-glsp/vitest-config@2.8.0-next.19(@vitest/coverage-v8@4.1.9)(vitest@4.1.9)':
+  '@eclipse-glsp/vitest-config@2.8.0(@vitest/coverage-v8@4.1.9)(vitest@4.1.9)':
     dependencies:
       '@vitest/coverage-v8': 4.1.9(vitest@4.1.9)
       vitest: 4.1.9(@types/node@22.19.21)(@vitest/coverage-v8@4.1.9)(esbuild@0.28.1)(terser@5.48.0)(yaml@2.9.0)
@@ -8247,11 +8238,11 @@ snapshots:
   '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.4':
     optional: true
 
-  '@napi-rs/wasm-runtime@1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
-      '@tybys/wasm-util': 0.10.2
+      '@tybys/wasm-util': 0.10.3
     optional: true
 
   '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
@@ -9580,11 +9571,6 @@ snapshots:
 
   '@tootallnate/once@2.0.1': {}
 
-  '@tybys/wasm-util@0.10.2':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
   '@tybys/wasm-util@0.10.3':
     dependencies:
       tslib: 2.8.1
@@ -9902,12 +9888,12 @@ snapshots:
       '@types/node': 22.19.21
     optional: true
 
-  '@typescript-eslint/eslint-plugin@8.61.0(@typescript-eslint/parser@8.61.0(eslint@10.5.0)(supports-color@8.1.1)(typescript@5.9.3))(eslint@10.5.0)(supports-color@8.1.1)(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.61.0(@typescript-eslint/parser@8.61.0(eslint@10.5.0)(typescript@5.9.3))(eslint@10.5.0)(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.61.0(eslint@10.5.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.61.0(eslint@10.5.0)(typescript@5.9.3)
       '@typescript-eslint/scope-manager': 8.61.0
-      '@typescript-eslint/type-utils': 8.61.0(eslint@10.5.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@typescript-eslint/type-utils': 8.61.0(eslint@10.5.0)(typescript@5.9.3)
       '@typescript-eslint/utils': 8.61.0(eslint@10.5.0)(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.61.0
       eslint: 10.5.0
@@ -9918,7 +9904,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.61.0(eslint@10.5.0)(supports-color@8.1.1)(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.61.0(eslint@10.5.0)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.61.0
       '@typescript-eslint/types': 8.61.0
@@ -9948,7 +9934,7 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  '@typescript-eslint/type-utils@8.61.0(eslint@10.5.0)(supports-color@8.1.1)(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@8.61.0(eslint@10.5.0)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/types': 8.61.0
       '@typescript-eslint/typescript-estree': 8.61.0(typescript@5.9.3)
@@ -10051,7 +10037,7 @@ snapshots:
     dependencies:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
-      '@napi-rs/wasm-runtime': 1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
   '@unrs/resolver-binding-win32-arm64-msvc@1.12.2':
@@ -11490,7 +11476,7 @@ snapshots:
     optionalDependencies:
       unrs-resolver: 1.12.2
 
-  eslint-import-resolver-typescript@4.4.5(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.61.0(eslint@10.5.0)(typescript@5.9.3))(eslint@10.5.0)(supports-color@8.1.1))(eslint@10.5.0)(supports-color@8.1.1):
+  eslint-import-resolver-typescript@4.4.5(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.61.0(eslint@10.5.0)(typescript@5.9.3))(eslint@10.5.0))(eslint@10.5.0):
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
       eslint: 10.5.0
@@ -11501,11 +11487,11 @@ snapshots:
       tinyglobby: 0.2.17
       unrs-resolver: 1.12.2
     optionalDependencies:
-      eslint-plugin-import-x: 4.16.2(@typescript-eslint/utils@8.61.0(eslint@10.5.0)(typescript@5.9.3))(eslint@10.5.0)(supports-color@8.1.1)
+      eslint-plugin-import-x: 4.16.2(@typescript-eslint/utils@8.61.0(eslint@10.5.0)(typescript@5.9.3))(eslint@10.5.0)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.61.0(eslint@10.5.0)(typescript@5.9.3))(eslint@10.5.0)(supports-color@8.1.1):
+  eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.61.0(eslint@10.5.0)(typescript@5.9.3))(eslint@10.5.0):
     dependencies:
       '@package-json/types': 0.0.12
       '@typescript-eslint/types': 8.61.0
@@ -11515,7 +11501,7 @@ snapshots:
       eslint-import-context: 0.1.9(unrs-resolver@1.12.2)
       is-glob: 4.0.3
       minimatch: 10.2.5
-      semver: 7.8.4
+      semver: 7.8.5
       stable-hash-x: 0.2.0
       unrs-resolver: 1.12.2
     optionalDependencies:
@@ -14094,10 +14080,10 @@ snapshots:
 
   typedarray@0.0.6: {}
 
-  typescript-eslint@8.61.0(eslint@10.5.0)(supports-color@8.1.1)(typescript@5.9.3):
+  typescript-eslint@8.61.0(eslint@10.5.0)(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.61.0(@typescript-eslint/parser@8.61.0(eslint@10.5.0)(supports-color@8.1.1)(typescript@5.9.3))(eslint@10.5.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.61.0(eslint@10.5.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 8.61.0(@typescript-eslint/parser@8.61.0(eslint@10.5.0)(typescript@5.9.3))(eslint@10.5.0)(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.61.0(eslint@10.5.0)(typescript@5.9.3)
       '@typescript-eslint/typescript-estree': 8.61.0(typescript@5.9.3)
       '@typescript-eslint/utils': 8.61.0(eslint@10.5.0)(typescript@5.9.3)
       eslint: 10.5.0


### PR DESCRIPTION
Prepare release v2.8.0

## Changes

- [build] Switch the example app build from webpack to esbuild, which significantly reduces build times [#322](https://github.com/eclipse-glsp/glsp-theia-integration/pull/322)
- [theia] Update the example projects to Theia 1.74.x; the minimum supported Theia version stays 1.66.x [#322](https://github.com/eclipse-glsp/glsp-theia-integration/pull/322) [#334](https://github.com/eclipse-glsp/glsp-theia-integration/pull/334) [#338](https://github.com/eclipse-glsp/glsp-theia-integration/pull/338)
    - `electron` is declared explicitly, as it became a peer dependency of `@theia/electron`
- [build] Migrate the build from yarn and lerna to pnpm workspaces [#330](https://github.com/eclipse-glsp/glsp-theia-integration/pull/330)
- [diagram] Report a diagram that fails to load in the widget instead of failing silently [#340](https://github.com/eclipse-glsp/glsp-theia-integration/pull/340)

### Potentially Breaking Changes

**Full Changelog**: https://github.com/eclipse-glsp/glsp-theia-integration/compare/v2.7.0...v2.8.0


Note: This pull request was created automatically. After merging, the automated publishing process will be started.
