### PR TITLE
GLSP-1722: Fix latest Theia compatibility build

### DIFF
--- a/.github/workflows/theia-compat.yml
+++ b/.github/workflows/theia-compat.yml
@@ -24,12 +24,16 @@ jobs:
         # Each Theia release supports only the electron version its own example app pins
         # (see examples/electron/package.json in the eclipse-theia/theia tag). Downgrading
         # Theia without downgrading electron breaks `theia rebuild:electron`/`theia build`,
-        # so pin the matching electron version per compat build. Omit `electron_version` to
-        # keep the version declared in examples/electron-app/package.json.
+        # so pin the matching Electron, Node.js, and React versions per compatibility build.
         include:
           - theia_version: 1.66.0
             electron_version: 38.4.0
+            node_version: 22.x
+            react_version: ^18.3.1
           - theia_version: latest
+            electron_version: 42.8.1
+            node_version: 24.x
+            react_version: ^19.0.0
     env:
       GLSP_REPO_DIR: '${{ github.workspace }}'
       GLSP_SERVER_PORT: '8081'
@@ -53,7 +57,7 @@ jobs:
           package_json_file: glsp-theia-integration/package.json
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 22.x
+          node-version: ${{ matrix.node_version }}
           cache: pnpm
           cache-dependency-path: glsp-theia-integration/pnpm-lock.yaml
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
@@ -68,7 +72,7 @@ jobs:
       - name: Change theia version
         run: |
           cd glsp-theia-integration
-          pnpm change:theia-version ${{ matrix.theia_version }} ${{ matrix.electron_version }}
+          pnpm change:theia-version ${{ matrix.theia_version }} ${{ matrix.electron_version }} ${{ matrix.react_version }}
       # Reinstall to apply the downgrade. Must run before `electron build` so theia's native
       # module backup/restore (.browser_modules) operates on the correctly downgraded tree.
       - name: Install downgraded dependencies

--- a/configs/change-theia-version.ts
+++ b/configs/change-theia-version.ts
@@ -48,7 +48,7 @@ const WORKSPACE_YAML_PATH = path.resolve(ROOT_PATH, 'pnpm-workspace.yaml');
 const COMPAT_BLOCK_BEGIN = '# BEGIN compat overrides (managed by change-theia-version.ts)';
 const COMPAT_BLOCK_END = '# END compat overrides';
 
-function updateTheiaDependencyVersion(appPath: string, version: string, electronVersion?: string): void {
+function updateTheiaDependencyVersion(appPath: string, version: string, electronVersion?: string, reactVersion?: string): void {
     const pkgJson = path.join(appPath, 'package.json');
     const pkg: { dependencies: Record<string, string>; devDependencies: Record<string, string> } = JSON.parse(
         fs.readFileSync(pkgJson, 'utf8')
@@ -68,6 +68,13 @@ function updateTheiaDependencyVersion(appPath: string, version: string, electron
 
     if (electronVersion) {
         pkg.devDependencies['electron'] = electronVersion;
+    }
+
+    if (reactVersion) {
+        pkg.dependencies['react'] = reactVersion;
+        pkg.dependencies['react-dom'] = reactVersion;
+        pkg.devDependencies['@types/react'] = reactVersion;
+        pkg.devDependencies['@types/react-dom'] = reactVersion;
     }
 
     fs.writeFileSync(pkgJson, JSON.stringify(pkg, undefined, 2));
@@ -118,12 +125,18 @@ if (electronVersion && !semver.validRange(electronVersion)) {
     process.exit(1);
 }
 
+const reactVersion = process.argv[4];
+if (reactVersion && !semver.validRange(reactVersion)) {
+    console.error(`Invalid React version number/range ${reactVersion}`);
+    process.exit(1);
+}
+
 updateCompatOverrides(version);
 
 if (fs.existsSync(BROWSER_APP_PATH)) {
-    updateTheiaDependencyVersion(BROWSER_APP_PATH, version);
+    updateTheiaDependencyVersion(BROWSER_APP_PATH, version, undefined, reactVersion);
 }
 
 if (fs.existsSync(ELECTRON_APP_PATH)) {
-    updateTheiaDependencyVersion(ELECTRON_APP_PATH, version, electronVersion);
+    updateTheiaDependencyVersion(ELECTRON_APP_PATH, version, electronVersion, reactVersion);
 }


### PR DESCRIPTION
- Match latest Theia with Electron 42.8.1, Node.js 24, and React 19
- Align React runtime and type peers in the compatibility switch
- Keep the Theia 1.66 baseline on Electron 38.4, Node.js 22, and React

Part of: https://github.com/eclipse-glsp/glsp/issues/1722

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-glsp/glsp/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See [SECURITY.md](https://github.com/eclipse-glsp/glsp/blob/master/SECURITY.md),
to learn how to report vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Changelog

<!-- Please check, when if it applies to your change. -->

- [ ] This PR should be mentioned in the changelog
- [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)
